### PR TITLE
Change flags to standard formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,19 +50,19 @@ Download the latest release from the Github repository and start it with:
 
 ```
 # if you got Nomad running on localhost
-./hashi-ui-<os>-<arch> --nomad.enable
+./hashi-ui-<os>-<arch> --nomad-enable
 
 # if you got Nomad running on a specific Protocol/IP/Port
-./hashi-ui-<os>-<arch> --nomad.enable --nomad.address http://IP:Port
+./hashi-ui-<os>-<arch> --nomad-enable --nomad-address http://IP:Port
 
 # if you got Consul running on localhost
-./hashi-ui-<os>-<arch> --consul.enable
+./hashi-ui-<os>-<arch> --consul-enable
 
 # if you got Consul running on a specific IP/Port
-./hashi-ui-<os>-<arch> --consul.enable  --consul.address IP:Port
+./hashi-ui-<os>-<arch> --consul-enable  --consul-address IP:Port
 
 # if you got nomad and Consul running on localhost
-./hashi-ui-<os>-<arch> --nomad.enable --consul.enable
+./hashi-ui-<os>-<arch> --nomad-enable --consul-enable
 ```
 
 This will start the hashi-ui server that will try to connect to local
@@ -99,27 +99,27 @@ hashi-ui can be controlled by both ENV or CLI flags as described below
 
 | Environment        	  | CLI (`--flag`)    		  | Default                 	| Description                                                                                                      |
 |-------------------------|---------------------------|-----------------------------|------------------------------------------------------------------------------------------------------------------|
-| `NOMAD_ENABLE`          | `nomad.enable`      	  | `false` 	                | Use `--nomad.enable` or env `NOMAD_ENABLE=1` to enable Nomad backend                                             |
-| `NOMAD_ADDR`            | `nomad.address`      	  | `http://127.0.0.1:4646` 	| Protocol + Host + Port for your .                                                                                |
-| `NOMAD_READ_ONLY`  	  | `nomad.read-only`   	  | `false` 		        	| Should hash-ui allowed to modify Nomad state (stop/start jobs and so forth)	                                   |
-| `NOMAD_CACERT`      	  | `nomad.ca_cert`      	  | `<empty>`   	            | (optional) path to a CA Cert file (remember to use `https://` in `NOMAD_ADDR` if you enable TLS)                 |
-| `NOMAD_CLIENT_CERT`  	  | `nomad.client_cert`       | `<empty>` 	                | (optional) path to a client cert file (remember to use `https://` in `NOMAD_ADDR` if you enable TLS)             |
-| `NOMAD_CLIENT_KEY`  	  | `nomad.client_key`        | `<empty>` 	                | (optional) path to a client key file (remember to use `https://` in `NOMAD_ADDR` if you enable TLS)          	   |
+| `NOMAD_ENABLE`          | `nomad-enable`      	  | `false` 	                | Use `--nomad-enable` or env `NOMAD_ENABLE=1` to enable Nomad backend                                             |
+| `NOMAD_ADDR`            | `nomad-address`      	  | `http://127.0.0.1:4646` 	| Protocol + Host + Port for your .                                                                                |
+| `NOMAD_READ_ONLY`  	  | `nomad-read-only`   	  | `false` 		        	| Should hash-ui allowed to modify Nomad state (stop/start jobs and so forth)	                                   |
+| `NOMAD_CACERT`      	  | `nomad-ca_cert`      	  | `<empty>`   	            | (optional) path to a CA Cert file (remember to use `https://` in `NOMAD_ADDR` if you enable TLS)                 |
+| `NOMAD_CLIENT_CERT`  	  | `nomad-client_cert`       | `<empty>` 	                | (optional) path to a client cert file (remember to use `https://` in `NOMAD_ADDR` if you enable TLS)             |
+| `NOMAD_CLIENT_KEY`  	  | `nomad-client_key`        | `<empty>` 	                | (optional) path to a client key file (remember to use `https://` in `NOMAD_ADDR` if you enable TLS)          	   |
 | `NOMAD_PORT_http` 	  | `<none>` 	              | `0.0.0.0:3000`          	| The IP + PORT to listen on (will overwrite `LISTEN_ADDRESS`)                                                     |
 
 ## Consul Configuration
 
 | Environment        	  | CLI (`--flag`)    		  | Default                 	| Description                                                                                                      |
 |-------------------------|---------------------------|-----------------------------|------------------------------------------------------------------------------------------------------------------|
-| `CONSUL_ENABLE`         | `consul.enable`      	  | `false` 	                | Use `--consul.enable` or env `CONSUL_ENABLE=1` to enable Consul backend                                          |
-| `CONSUL_ADDR`           | `consul.address`      	  | `127.0.0.1:8500`            | Host + Port for your Consul server, e.g. `localhost:8500` (Do not include protocol)                              |
-| `CONSUL_READ_ONLY`  	  | `consul.read-only`   	  | `false` 		        	| Should hash-ui allowed to modify Consul state (modify KV, Services and so forth)                                 |
+| `CONSUL_ENABLE`         | `consul-enable`      	  | `false` 	                | Use `--consul-enable` or env `CONSUL_ENABLE=1` to enable Consul backend                                          |
+| `CONSUL_ADDR`           | `consul-address`      	  | `127.0.0.1:8500`            | Host + Port for your Consul server, e.g. `localhost:8500` (Do not include protocol)                              |
+| `CONSUL_READ_ONLY`  	  | `consul-read-only`   	  | `false` 		        	| Should hash-ui allowed to modify Consul state (modify KV, Services and so forth)                                 |
 
 ## Instrumentation Configuration
 
 | Environment        	  | CLI (`--flag`)    		  | Default                 	| Description                                                                                                      |
 |-------------------------|---------------------------|-----------------------------|------------------------------------------------------------------------------------------------------------------|
-| `NEWRELIC_APP_NAME`     | `newrelic.app_name`  	  | `hashi-ui`               	| (optional) NewRelic application name                                                                             |
+| `NEWRELIC_APP_NAME`     | `newrelic.app-name`  	  | `hashi-ui`               	| (optional) NewRelic application name                                                                             |
 | `NEWRELIC_LICENSE`      | `newrelic.license`  	  | `<empty>`          	  		| (optional) NewRelic license key                                                                                  |
 
 
@@ -136,7 +136,7 @@ nomad agent -server -client -bootstrap-expect 1 -data-dir /tmp/nomad
 Now you can run Hashi UI in other terminal (we assume you have it in PATH):
 
 ```
-hashi-ui-<os>-<arch> --nomad.enable
+hashi-ui-<os>-<arch> --nomad-enable
 ```
 
 Open browser and visit [http://127.0.0.1:3000](http://127.0.0.1:3000).
@@ -146,7 +146,7 @@ Open browser and visit [http://127.0.0.1:3000](http://127.0.0.1:3000).
 You can run the Consul UI against the official HashiCorp Consul demo like this:
 
 ```
-hashi-ui-<os>-<arch> --consul.enable --consul.address demo.consul.io
+hashi-ui-<os>-<arch> --consul-enable --consul-address demo.consul.io
 ```
 
 Open browser and visit [http://127.0.0.1:3000](http://127.0.0.1:3000).

--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ hashi-ui can be controlled by both ENV or CLI flags as described below
 | `NOMAD_ENABLE`          | `nomad-enable`      	  | `false` 	                | Use `--nomad-enable` or env `NOMAD_ENABLE=1` to enable Nomad backend                                             |
 | `NOMAD_ADDR`            | `nomad-address`      	  | `http://127.0.0.1:4646` 	| Protocol + Host + Port for your .                                                                                |
 | `NOMAD_READ_ONLY`  	  | `nomad-read-only`   	  | `false` 		        	| Should hash-ui allowed to modify Nomad state (stop/start jobs and so forth)	                                   |
-| `NOMAD_CACERT`      	  | `nomad-ca_cert`      	  | `<empty>`   	            | (optional) path to a CA Cert file (remember to use `https://` in `NOMAD_ADDR` if you enable TLS)                 |
-| `NOMAD_CLIENT_CERT`  	  | `nomad-client_cert`       | `<empty>` 	                | (optional) path to a client cert file (remember to use `https://` in `NOMAD_ADDR` if you enable TLS)             |
-| `NOMAD_CLIENT_KEY`  	  | `nomad-client_key`        | `<empty>` 	                | (optional) path to a client key file (remember to use `https://` in `NOMAD_ADDR` if you enable TLS)          	   |
+| `NOMAD_CACERT`      	  | `nomad-ca-cert`      	  | `<empty>`   	            | (optional) path to a CA Cert file (remember to use `https://` in `NOMAD_ADDR` if you enable TLS)                 |
+| `NOMAD_CLIENT_CERT`  	  | `nomad-client-cert`       | `<empty>` 	                | (optional) path to a client cert file (remember to use `https://` in `NOMAD_ADDR` if you enable TLS)             |
+| `NOMAD_CLIENT_KEY`  	  | `nomad-client-key`        | `<empty>` 	                | (optional) path to a client key file (remember to use `https://` in `NOMAD_ADDR` if you enable TLS)          	   |
 | `NOMAD_PORT_http` 	  | `<none>` 	              | `0.0.0.0:3000`          	| The IP + PORT to listen on (will overwrite `LISTEN_ADDRESS`)                                                     |
 
 ## Consul Configuration

--- a/backend/config.go
+++ b/backend/config.go
@@ -19,7 +19,7 @@ var (
 	flagNewRelicAppName = flag.String("newrelic-app-name", "hashi-ui",
 		"The NewRelic app name. "+flagDefault(defaultConfig.NewRelicAppName))
 
-	flagNewRelicLicense = flag.String("newreliclicense", "",
+	flagNewRelicLicense = flag.String("newrelic-license", "",
 		"The NewRelic license key. "+flagDefault(defaultConfig.NewRelicLicense))
 )
 

--- a/backend/config.go
+++ b/backend/config.go
@@ -16,10 +16,10 @@ var (
 	flagListenAddress = flag.String("listen-address", "",
 		"The address on which to expose the web interface. "+flagDefault(defaultConfig.ListenAddress))
 
-	flagNewRelicAppName = flag.String("newrelic.app_name", "hashi-ui",
+	flagNewRelicAppName = flag.String("newrelic-app-name", "hashi-ui",
 		"The NewRelic app name. "+flagDefault(defaultConfig.NewRelicAppName))
 
-	flagNewRelicLicense = flag.String("newrelic.license", "",
+	flagNewRelicLicense = flag.String("newreliclicense", "",
 		"The NewRelic license key. "+flagDefault(defaultConfig.NewRelicLicense))
 )
 

--- a/backend/consul_config.go
+++ b/backend/consul_config.go
@@ -7,13 +7,13 @@ import (
 )
 
 var (
-	flagConsulEnable = flag.Bool("consul.enable", false, "Whether Consul engine should be started. "+
+	flagConsulEnable = flag.Bool("consul-enable", false, "Whether Consul engine should be started. "+
 		"Overrides the CONSUL_ENABLE environment variable if set. "+flagDefault(strconv.FormatBool(defaultConfig.ConsulEnable)))
 
-	flagConsulReadOnly = flag.Bool("consul.read-only", false, "Whether Hashi-UI should be allowed to modify Consul state. "+
+	flagConsulReadOnly = flag.Bool("consul-read-only", false, "Whether Hashi-UI should be allowed to modify Consul state. "+
 		"Overrides the CONSUL_READ_ONLY environment variable if set. "+flagDefault(strconv.FormatBool(defaultConfig.ConsulEnable)))
 
-	flagConsulAddress = flag.String("consul.address", "", "The address of the Consul server. "+
+	flagConsulAddress = flag.String("consul-address", "", "The address of the Consul server. "+
 		"Overrides the CONSUL_ADDR environment variable if set. "+flagDefault(defaultConfig.ConsulAddress))
 )
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -81,36 +81,36 @@ func main() {
 	logger.Infof("| log-level       	: %-50s |", cfg.LogLevel)
 
 	if cfg.NewRelicAppName != "" && cfg.NewRelicLicense != "" {
-		logger.Infof("| newrelic.app_name   : %-50s |", cfg.NewRelicAppName)
-		logger.Infof("| newrelic.license    : %-50s |", strings.Repeat("*", len(cfg.NewRelicLicense)))
+		logger.Infof("| newrelic-app_name   : %-50s |", cfg.NewRelicAppName)
+		logger.Infof("| newrelic-license    : %-50s |", strings.Repeat("*", len(cfg.NewRelicLicense)))
 	}
 
 	// Nomad
-	logger.Infof("| nomad.enable     	: %-50t |", cfg.NomadEnable)
+	logger.Infof("| nomad-enable     	: %-50t |", cfg.NomadEnable)
 	if cfg.NomadReadOnly {
-		logger.Infof("| nomad.read-only       : %-50s |", "Yes")
+		logger.Infof("| nomad-read-only       : %-50s |", "Yes")
 	} else {
-		logger.Infof("| nomad.read-only       : %-50s |", "No (Hashi-UI can change Nomad state)")
+		logger.Infof("| nomad-read-only       : %-50s |", "No (Hashi-UI can change Nomad state)")
 	}
-	logger.Infof("| nomad.address         : %-50s |", cfg.NomadAddress)
-	logger.Infof("| nomad.ca_cert         : %-50s |", cfg.NomadCACert)
-	logger.Infof("| nomad.client_cert     : %-50s |", cfg.NomadClientCert)
-	logger.Infof("| nomad.client_key      : %-50s |", cfg.NomadClientKey)
+	logger.Infof("| nomad-address         : %-50s |", cfg.NomadAddress)
+	logger.Infof("| nomad-ca_cert         : %-50s |", cfg.NomadCACert)
+	logger.Infof("| nomad-client_cert     : %-50s |", cfg.NomadClientCert)
+	logger.Infof("| nomad-client_key      : %-50s |", cfg.NomadClientKey)
 
 	// Consul
-	logger.Infof("| consul.enable     	: %-50t |", cfg.ConsulEnable)
+	logger.Infof("| consul-enable     	: %-50t |", cfg.ConsulEnable)
 	if cfg.ConsulReadOnly {
-		logger.Infof("| consul.read-only     : %-50s |", "Yes")
+		logger.Infof("| consul-read-only     : %-50s |", "Yes")
 	} else {
-		logger.Infof("| consul.read-only     : %-50s |", "No (Hashi-UI can change Consul state)")
+		logger.Infof("| consul-read-only     : %-50s |", "No (Hashi-UI can change Consul state)")
 	}
-	logger.Infof("| consul.address       : %-50s |", cfg.ConsulAddress)
+	logger.Infof("| consul-address       : %-50s |", cfg.ConsulAddress)
 
 	logger.Infof("-----------------------------------------------------------------------------")
 	logger.Infof("")
 
 	if !cfg.NomadEnable && !cfg.ConsulEnable {
-		logger.Fatal("Please enable at least Consul (--consul.enable) or Nomad (--nomad.enable)")
+		logger.Fatal("Please enable at least Consul (--consul-enable) or Nomad (--nomad-enable)")
 	}
 
 	myAssetFS := assetFS()

--- a/backend/main.go
+++ b/backend/main.go
@@ -81,7 +81,7 @@ func main() {
 	logger.Infof("| log-level       	: %-50s |", cfg.LogLevel)
 
 	if cfg.NewRelicAppName != "" && cfg.NewRelicLicense != "" {
-		logger.Infof("| newrelic-app_name   : %-50s |", cfg.NewRelicAppName)
+		logger.Infof("| newrelic-app-name   : %-50s |", cfg.NewRelicAppName)
 		logger.Infof("| newrelic-license    : %-50s |", strings.Repeat("*", len(cfg.NewRelicLicense)))
 	}
 
@@ -93,9 +93,9 @@ func main() {
 		logger.Infof("| nomad-read-only       : %-50s |", "No (Hashi-UI can change Nomad state)")
 	}
 	logger.Infof("| nomad-address         : %-50s |", cfg.NomadAddress)
-	logger.Infof("| nomad-ca_cert         : %-50s |", cfg.NomadCACert)
-	logger.Infof("| nomad-client_cert     : %-50s |", cfg.NomadClientCert)
-	logger.Infof("| nomad-client_key      : %-50s |", cfg.NomadClientKey)
+	logger.Infof("| nomad-ca-cert         : %-50s |", cfg.NomadCACert)
+	logger.Infof("| nomad-client-cert     : %-50s |", cfg.NomadClientCert)
+	logger.Infof("| nomad-client-key      : %-50s |", cfg.NomadClientKey)
 
 	// Consul
 	logger.Infof("| consul-enable     	: %-50t |", cfg.ConsulEnable)

--- a/backend/nomad_config.go
+++ b/backend/nomad_config.go
@@ -8,22 +8,22 @@ import (
 )
 
 var (
-	flagNomadEnable = flag.Bool("nomad.enable", false, "Whether Nomad engine should be started. "+
+	flagNomadEnable = flag.Bool("nomad-enable", false, "Whether Nomad engine should be started. "+
 		"Overrides the NOMAD_ENABLE environment variable if set. "+flagDefault(strconv.FormatBool(defaultConfig.NomadEnable)))
 
-	flagNomadReadOnly = flag.Bool("nomad.read-only", false, "Whether Hashi-UI should be allowed to modify Nomad state. "+
+	flagNomadReadOnly = flag.Bool("nomad-read-only", false, "Whether Hashi-UI should be allowed to modify Nomad state. "+
 		"Overrides the NOMAD_READ_ONLY environment variable if set. "+flagDefault(strconv.FormatBool(defaultConfig.NomadReadOnly)))
 
-	flagNomadAddress = flag.String("nomad.address", "", "The address of the Nomad server. "+
+	flagNomadAddress = flag.String("nomad-address", "", "The address of the Nomad server. "+
 		"Overrides the NOMAD_ADDR environment variable if set. "+flagDefault(defaultConfig.NomadAddress))
 
-	flagNomadCACert = flag.String("nomad.ca_cert", "", "Path to the Nomad TLS CA Cert File. "+
+	flagNomadCACert = flag.String("nomad-ca_cert", "", "Path to the Nomad TLS CA Cert File. "+
 		"Overrides the NOMAD_CACERT environment variable if set. "+flagDefault(defaultConfig.NomadCACert))
 
-	flagNomadClientCert = flag.String("nomad.client_cert", "", "Path to the Nomad Client Cert File. "+
+	flagNomadClientCert = flag.String("nomad-client_cert", "", "Path to the Nomad Client Cert File. "+
 		"Overrides the NOMAD_CLIENT_CERT environment variable if set. "+flagDefault(defaultConfig.NomadClientCert))
 
-	flagNomadClientKey = flag.String("nomad.client_key", "", "Path to the Nomad Client Key File. "+
+	flagNomadClientKey = flag.String("nomad-client_key", "", "Path to the Nomad Client Key File. "+
 		"Overrides the NOMAD_CLIENT_KEY environment variable if set. "+flagDefault(defaultConfig.NomadClientKey))
 )
 

--- a/backend/nomad_config.go
+++ b/backend/nomad_config.go
@@ -17,13 +17,13 @@ var (
 	flagNomadAddress = flag.String("nomad-address", "", "The address of the Nomad server. "+
 		"Overrides the NOMAD_ADDR environment variable if set. "+flagDefault(defaultConfig.NomadAddress))
 
-	flagNomadCACert = flag.String("nomad-ca_cert", "", "Path to the Nomad TLS CA Cert File. "+
+	flagNomadCACert = flag.String("nomad-ca-cert", "", "Path to the Nomad TLS CA Cert File. "+
 		"Overrides the NOMAD_CACERT environment variable if set. "+flagDefault(defaultConfig.NomadCACert))
 
-	flagNomadClientCert = flag.String("nomad-client_cert", "", "Path to the Nomad Client Cert File. "+
+	flagNomadClientCert = flag.String("nomad-client-cert", "", "Path to the Nomad Client Cert File. "+
 		"Overrides the NOMAD_CLIENT_CERT environment variable if set. "+flagDefault(defaultConfig.NomadClientCert))
 
-	flagNomadClientKey = flag.String("nomad-client_key", "", "Path to the Nomad Client Key File. "+
+	flagNomadClientKey = flag.String("nomad-client-key", "", "Path to the Nomad Client Key File. "+
 		"Overrides the NOMAD_CLIENT_KEY environment variable if set. "+flagDefault(defaultConfig.NomadClientKey))
 )
 


### PR DESCRIPTION
Following guidance from the [GNU Coding Standards](http://www.gnu.org/prep/standards/standards.html), command line flags should not contain dots(.) but dashes(-). All occurrences of dots have been replaced with dashes