### PR TITLE
adding nomad-skip-verify TLS option for dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ hashi-ui can be controlled by both ENV or CLI flags as described below
 | `NOMAD_CACERT`      	  | `nomad-ca-cert`      	  | `<empty>`   	            | (optional) path to a CA Cert file (remember to use `https://` in `NOMAD_ADDR` if you enable TLS)                 |
 | `NOMAD_CLIENT_CERT`  	  | `nomad-client-cert`       | `<empty>` 	                | (optional) path to a client cert file (remember to use `https://` in `NOMAD_ADDR` if you enable TLS)             |
 | `NOMAD_CLIENT_KEY`  	  | `nomad-client-key`        | `<empty>` 	                | (optional) path to a client key file (remember to use `https://` in `NOMAD_ADDR` if you enable TLS)          	   |
+| `NOMAD_SKIP_VERIFY`  	  | `nomad-skip-verify`        | `false` 	                | (optional) skip TLS verification, not recommended (remember to use `https://` in `NOMAD_ADDR` if you enable TLS)          	   |
 | `NOMAD_PORT_http` 	  | `<none>` 	              | `0.0.0.0:3000`          	| The IP + PORT to listen on (will overwrite `LISTEN_ADDRESS`)                                                     |
 
 ## Consul Configuration

--- a/backend/config.go
+++ b/backend/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	NomadClientCert string
 	NomadClientKey  string
 	NomadReadOnly   bool
+	NomadSkipVerify bool
 
 	ConsulEnable   bool
 	ConsulReadOnly bool

--- a/backend/nomad_config.go
+++ b/backend/nomad_config.go
@@ -11,6 +11,9 @@ var (
 	flagNomadEnable = flag.Bool("nomad-enable", false, "Whether Nomad engine should be started. "+
 		"Overrides the NOMAD_ENABLE environment variable if set. "+flagDefault(strconv.FormatBool(defaultConfig.NomadEnable)))
 
+	flagNomadSkipVerify = flag.Bool("nomad-skip-verify", false, "Whether Hashi-UI should skip TLS verification, not recommended. "+
+		"Overrides the NOMAD_SKIP_VERIFY environment variable if set. "+flagDefault(strconv.FormatBool(defaultConfig.NomadSkipVerify)))
+
 	flagNomadReadOnly = flag.Bool("nomad-read-only", false, "Whether Hashi-UI should be allowed to modify Nomad state. "+
 		"Overrides the NOMAD_READ_ONLY environment variable if set. "+flagDefault(strconv.FormatBool(defaultConfig.NomadReadOnly)))
 
@@ -25,8 +28,7 @@ var (
 
 	flagNomadClientKey = flag.String("nomad-client-key", "", "Path to the Nomad Client Key File. "+
 		"Overrides the NOMAD_CLIENT_KEY environment variable if set. "+flagDefault(defaultConfig.NomadClientKey))
-)
-
+ )
 // ParseNomadEnvConfig ...
 func ParseNomadEnvConfig(c *Config) {
 	nomadEnable, ok := syscall.Getenv("NOMAD_ENABLE")
@@ -67,6 +69,10 @@ func ParseNomadEnvConfig(c *Config) {
 	nomadClientKey, ok := syscall.Getenv("NOMAD_CLIENT_KEY")
 	if ok {
 		c.NomadClientKey = nomadClientKey
+	}
+	nomadSkipVerify, ok := syscall.Getenv("NOMAD_SKIP_VERIFY")
+	if ok {
+		c.NomadSkipVerify = nomadSkipVerify != "false"
 	}
 }
 

--- a/backend/nomad_config.go
+++ b/backend/nomad_config.go
@@ -28,7 +28,8 @@ var (
 
 	flagNomadClientKey = flag.String("nomad-client-key", "", "Path to the Nomad Client Key File. "+
 		"Overrides the NOMAD_CLIENT_KEY environment variable if set. "+flagDefault(defaultConfig.NomadClientKey))
- )
+)
+
 // ParseNomadEnvConfig ...
 func ParseNomadEnvConfig(c *Config) {
 	nomadEnable, ok := syscall.Getenv("NOMAD_ENABLE")

--- a/backend/nomad_region.go
+++ b/backend/nomad_region.go
@@ -58,6 +58,7 @@ func CreateNomadRegionClient(c *Config, region string) (*api.Client, error) {
 		CACert:     c.NomadCACert,
 		ClientCert: c.NomadClientCert,
 		ClientKey:  c.NomadClientKey,
+		Insecure:   c.NomadSkipVerify,
 	}
 
 	return api.NewClient(config)


### PR DESCRIPTION
I rolled this out and tested on my end. The skip TLS option available in Nomad works as intended. 