### PR TITLE
Fix popup times in allocation events details

### DIFF
--- a/frontend/src/components/AllocationInfo/AllocationInfo.js
+++ b/frontend/src/components/AllocationInfo/AllocationInfo.js
@@ -60,13 +60,16 @@ class AllocationInfo extends Component {
                 const output = (
                   <TableRow key={ index }>
                     <TableRowColumn style={{ width: 180 }}>
-                      <FormatTime time={ element.Time } />
+                      <FormatTime
+                        time={ element.Time }
+                        identifier={ `${allocation.ID}-${element.Time}` }
+                      />
                     </TableRowColumn>
                     <TableRowColumn style={{ width: 180 }}>
                       <FormatTime
                         time={ element.Time }
                         now={ lastEventTime }
-                        identifier={ allocation.ID }
+                        identifier={ `${allocation.ID}-${element.Time}` }
                         durationInterval='ms'
                         durationFormat='h [hour] m [min] s [seconds]'
                       />


### PR DESCRIPTION
When you go in the "Task state history" in a allocation page for a task, you can see the latest events at the bottom of the page.

The date of the events are humanized in the table, but when you hover over it, you get the real time when the event occurred in a small popup. The problem is: the popup always show the date of the last event.