### PR TITLE
Added config for HideEnvData

### DIFF
--- a/backend/config.go
+++ b/backend/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	ConsulReadOnly bool
 	ConsulAddress  string
 	ConsulACLToken string
+	HideEnvData    bool
 }
 
 // DefaultConfig is the basic out-of-the-box configuration for hashi-ui
@@ -59,6 +60,7 @@ func DefaultConfig() *Config {
 
 		ConsulReadOnly: false,
 		ConsulAddress:  "127.0.0.1:8500",
+		HideEnvData:    false,
 	}
 }
 

--- a/backend/nomad_connection.go
+++ b/backend/nomad_connection.go
@@ -555,10 +555,12 @@ func (c *NomadConnection) watchJob(action Action) {
 		default:
 			job, meta, err := c.region.Client.Jobs().Info(jobID, q)
 
-			for _, taskGroup := range job.TaskGroups {
-				for _, task := range taskGroup.Tasks {
-					for k := range task.Env {
-						task.Env[k] = ""
+			if defaultConfig.HideEnvData {
+				for _, taskGroup := range job.TaskGroups {
+					for _, task := range taskGroup.Tasks {
+						for k := range task.Env {
+							task.Env[k] = ""
+						}
 					}
 				}
 			}
@@ -910,7 +912,7 @@ func (c *NomadConnection) submitJob(action Action) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	index := uint64(r.Int())
 
-	if c.region.Config.NomadReadOnly {
+	if c.region.Config.NomadReadOnly || defaultConfig.HideEnvData {
 		logger.Errorf("Unable to submit job: NomadReadOnly is set to true")
 		c.send <- &Action{Type: errorNotification, Payload: "The backend server is in read-only mode", Index: index}
 		return

--- a/backend/nomad_connection.go
+++ b/backend/nomad_connection.go
@@ -912,9 +912,15 @@ func (c *NomadConnection) submitJob(action Action) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	index := uint64(r.Int())
 
-	if c.region.Config.NomadReadOnly || defaultConfig.HideEnvData {
+	if c.region.Config.NomadReadOnly {
 		logger.Errorf("Unable to submit job: NomadReadOnly is set to true")
 		c.send <- &Action{Type: errorNotification, Payload: "The backend server is in read-only mode", Index: index}
+		return
+	}
+
+	if defaultConfig.HideEnvData {
+		logger.Errorf("Unable to submit job: HideEnvData is set to true")
+		c.send <- &Action{Type: errorNotification, Payload: "HideEnvData must be false to submit job", Index: index}
 		return
 	}
 

--- a/backend/nomad_connection.go
+++ b/backend/nomad_connection.go
@@ -555,6 +555,14 @@ func (c *NomadConnection) watchJob(action Action) {
 		default:
 			job, meta, err := c.region.Client.Jobs().Info(jobID, q)
 
+			for _, taskGroup := range job.TaskGroups {
+				for _, task := range taskGroup.Tasks {
+					for k := range task.Env {
+						task.Env[k] = ""
+					}
+				}
+			}
+
 			if err != nil {
 				c.Errorf("connection: unable to fetch job info: %s", err)
 				time.Sleep(10 * time.Second)

--- a/backend/nomad_region.go
+++ b/backend/nomad_region.go
@@ -245,7 +245,7 @@ func (n *NomadRegion) watchJobs() {
 }
 
 func (n *NomadRegion) updateJob(job *api.Job) (*Action, error) {
-	if n.Config.NomadReadOnly {
+	if n.Config.NomadReadOnly || defaultConfig.HideEnvData {
 		logger.Errorf("Unable to run jon: NomadReadOnly is set to true")
 		return &Action{Type: errorNotification, Payload: "The backend server is set to read-only"}, errors.New("Nomad is in read-only mode")
 	}

--- a/backend/nomad_region.go
+++ b/backend/nomad_region.go
@@ -245,9 +245,15 @@ func (n *NomadRegion) watchJobs() {
 }
 
 func (n *NomadRegion) updateJob(job *api.Job) (*Action, error) {
-	if n.Config.NomadReadOnly || defaultConfig.HideEnvData {
-		logger.Errorf("Unable to run jon: NomadReadOnly is set to true")
+	if n.Config.NomadReadOnly {
+		logger.Errorf("Unable to run job: NomadReadOnly is set to true")
 		return &Action{Type: errorNotification, Payload: "The backend server is set to read-only"}, errors.New("Nomad is in read-only mode")
+	}
+
+	if defaultConfig.HideEnvData {
+		logger.Errorf("Unable to submit job: HideEnvData is set to true")
+		c.send <- &Action{Type: errorNotification, Payload: "HideEnvData must be false to submit job", Index: index}
+		return
 	}
 
 	logger.Infof("Started run job with id: %s", job.ID)


### PR DESCRIPTION
Should there be a separate conditional for `if c.region.Config.NomadReadOnly || defaultConfig.HideEnvData {
		logger.Errorf("Unable to submit job: NomadReadOnly is set to true")
		c.send <- &Action{Type: errorNotification, Payload: "The backend server is in read-only mode", Index: index}
		return
	}` 

> for example unable to submit because of HideEnvData