### PR TITLE
Pass TLS bool to backend for file access actions

### DIFF
--- a/backend/nomad_connection.go
+++ b/backend/nomad_connection.go
@@ -641,7 +641,7 @@ func (c *NomadConnection) watchClientStats(action Action) {
 	}
 }
 
-func nodeUrl(payload map[string]interface{}) string {
+func nodeUrl(params map[string]interface{}) string {
 	addr := params["addr"].(string)
 	if params["secure"].(bool) {
 		return fmt.Sprintf("https://%s", addr)

--- a/backend/nomad_connection.go
+++ b/backend/nomad_connection.go
@@ -641,18 +641,25 @@ func (c *NomadConnection) watchClientStats(action Action) {
 	}
 }
 
+func nodeUrl(payload map[string]interface{}) string {
+	addr := params["addr"].(string)
+	if params["secure"].(bool) {
+		return fmt.Sprintf("https://%s", addr)
+	}
+	return fmt.Sprintf("http://%s", addr)
+}
+
 func (c *NomadConnection) fetchDir(action Action) {
 	params, ok := action.Payload.(map[string]interface{})
 	if !ok {
 		c.Errorf("Could not decode payload")
 		return
 	}
-	addr := params["addr"].(string)
 	path := params["path"].(string)
 	allocID := params["allocID"].(string)
 
 	config := api.DefaultConfig()
-	config.Address = fmt.Sprintf("http://%s", addr)
+	config.Address = nodeUrl(params)
 
 	client, err := api.NewClient(config)
 	if err != nil {
@@ -681,12 +688,11 @@ func (c *NomadConnection) watchFile(action Action) {
 		return
 	}
 
-	addr := params["addr"].(string)
 	path := params["path"].(string)
 	allocID := params["allocID"].(string)
 
 	config := api.DefaultConfig()
-	config.Address = fmt.Sprintf("http://%s", addr)
+	config.Address = nodeUrl(params)
 
 	client, err := api.NewClient(config)
 	if err != nil {

--- a/frontend/src/components/AllocationFiles/AllocationFiles.js
+++ b/frontend/src/components/AllocationFiles/AllocationFiles.js
@@ -165,6 +165,7 @@ class AllocationFiles extends Component {
       type: FETCH_DIR,
       payload: {
         addr: props.node.HTTPAddr,
+        secure: props.node.TLSEnabled,
         path: dir || '/',
         allocID: props.allocation.ID
       }
@@ -182,6 +183,7 @@ class AllocationFiles extends Component {
       type: WATCH_FILE,
       payload: {
         addr: props.node.HTTPAddr,
+        secure: props.node.TLSEnabled,
         path: filePath,
         allocID: props.allocation.ID
       }


### PR DESCRIPTION
When using secured instances of nomad, I wasn't able to view logs because the instantiations of the nomad API client for those methods assumed that the remote node would be using http.

This pull request adds the TLSEnabled flag, available in the node detail, to the relevant action payloads and uses it to choose the appropriate protocol when instantiating the nomad API client.