### PR TITLE
Properly quote path components in the Nomad top bars

### DIFF
--- a/frontend/src/components/AllocationTopbar/AllocationTopbar.js
+++ b/frontend/src/components/AllocationTopbar/AllocationTopbar.js
@@ -11,8 +11,8 @@ const rawIcon = <FontIcon className='material-icons'>code</FontIcon>
 class _AllocationTopbar extends PureComponent {
 
   handleActive (tab) {
-    const prefix = `/nomad/${this.props.router.params.region}/allocations/${this.props.allocation.ID}`
-    this.props.router.push(prefix + '/' + tab)
+    const path = ['nomad', this.props.router.params.region, 'allocations', this.props.allocation.ID, tab]
+    this.props.router.push(path.map(encodeURIComponent).join('/'))
   }
 
   getActiveTab () {

--- a/frontend/src/components/ClientTopbar/ClientTopbar.js
+++ b/frontend/src/components/ClientTopbar/ClientTopbar.js
@@ -12,8 +12,8 @@ const rawIcon = <FontIcon className='material-icons'>code</FontIcon>
 class _ClientTopbar extends PureComponent {
 
   handleActive (tab) {
-    const prefix = `/nomad/${this.props.router.params.region}/clients/${this.props.node.ID}`
-    this.props.router.push(prefix + '/' + tab)
+    const path = ['nomad', this.props.router.params.region, 'clients', this.props.node.ID, tab]
+    this.props.router.push(path.map(encodeURIComponent).join('/'))
   }
 
   getActiveTab () {

--- a/frontend/src/components/EvaluationTopbar/EvaluationTopbar.js
+++ b/frontend/src/components/EvaluationTopbar/EvaluationTopbar.js
@@ -10,8 +10,8 @@ const rawIcon = <FontIcon className='material-icons'>code</FontIcon>
 class _EvaluationTopbar extends PureComponent {
 
   handleActive (tab) {
-    const prefix = `/nomad/${this.props.router.params.region}/evaluations/${this.props.evaluation.ID}`
-    this.props.router.push(prefix + '/' + tab)
+    const path = ['nomad', this.props.router.params.region, 'evaluations', this.props.evaluation.ID, tab]
+    this.props.router.push(path.map(encodeURIComponent).join('/'))
   }
 
   getActiveTab () {

--- a/frontend/src/components/JobTopbar/JobTopbar.js
+++ b/frontend/src/components/JobTopbar/JobTopbar.js
@@ -12,8 +12,8 @@ const rawIcon = <FontIcon className='material-icons'>code</FontIcon>
 class _JobTopbar extends PureComponent {
 
   handleActive (tab) {
-    const prefix = `/nomad/${this.props.router.params.region}/jobs/${this.props.job.Name}`
-    this.props.router.push(prefix + '/' + tab)
+    const path = ['nomad', this.props.router.params.region, 'jobs', this.props.job.Name, tab]
+    this.props.router.push(path.map(encodeURIComponent).join('/'))
   }
 
   getActiveTab () {

--- a/frontend/src/components/ServerTopbar/ServerTopbar.js
+++ b/frontend/src/components/ServerTopbar/ServerTopbar.js
@@ -9,8 +9,8 @@ const rawIcon = <FontIcon className='material-icons'>code</FontIcon>
 class _ViewServerTopbar extends PureComponent {
 
   handleActive (tab) {
-    const prefix = `/nomad/${this.props.router.params.region}/servers/${this.props.member.Name}`
-    this.props.router.push(prefix + '/' + tab)
+    const path = ['nomad', this.props.router.params.region, 'servers', this.props.member.Name, tab]
+    this.props.router.push(path.map(encodeURIComponent).join('/'))
   }
 
   getActiveTab () {


### PR DESCRIPTION
This fixes accessing components which have "/" in their value, such as a
Nomad allocation for a batch instance ("my-batch-job/timesamp")