### PR TITLE
Improve evaluation info tab

### DIFF
--- a/frontend/src/components/EvaluationInfo/EvaluationInfo.js
+++ b/frontend/src/components/EvaluationInfo/EvaluationInfo.js
@@ -5,6 +5,7 @@ import { Card, CardTitle, CardText } from 'material-ui/Card'
 import MetaPayload from '../MetaPayload/MetaPayload'
 import EvaluationLink from '../EvaluationLink/EvaluationLink'
 import JobLink from '../JobLink/JobLink'
+import { WATCH_EVAL, UNWATCH_EVAL } from '../../sagas/event'
 
 const evaluationProps = [
   'ID',
@@ -19,6 +20,15 @@ const evaluationProps = [
 ]
 
 class EvaluationInfo extends Component {
+
+  shouldComponentUpdate(nextProps) {
+    if (this.props.params.evalId !== nextProps.routeParams.evalId) {
+      this.props.dispatch({ type: UNWATCH_EVAL, payload: this.props.params.evalId })
+      this.props.dispatch({ type: WATCH_EVAL, payload: nextProps.routeParams.evalId})
+    }
+    return true;
+  }
+
   render () {
     const evaluation = this.props.evaluation
     const evalValues = {}
@@ -60,7 +70,9 @@ function mapStateToProps ({ evaluation }) {
 }
 
 EvaluationInfo.propTypes = {
-  evaluation: PropTypes.object.isRequired
+  dispatch: PropTypes.func.isRequired,
+  evaluation: PropTypes.object.isRequired,
+  params: PropTypes.object.isRequired,
 }
 
 export default connect(mapStateToProps)(EvaluationInfo)

--- a/frontend/src/components/EvaluationInfo/EvaluationInfo.js
+++ b/frontend/src/components/EvaluationInfo/EvaluationInfo.js
@@ -1,37 +1,58 @@
-import React, { PropTypes } from 'react'
+import React, { Component, PropTypes } from 'react'
 import { connect } from 'react-redux'
 import { Grid, Row, Col } from 'react-flexbox-grid'
 import { Card, CardTitle, CardText } from 'material-ui/Card'
+import MetaPayload from '../MetaPayload/MetaPayload'
+import EvaluationLink from '../EvaluationLink/EvaluationLink'
+import JobLink from '../JobLink/JobLink'
 
 const evaluationProps = [
   'ID',
   'Status',
+  'StatusDescription',
+  'NextEval',
+  'PreviousEval',
   'Priority',
   'Type',
   'JobID',
   'TriggeredBy'
 ]
 
-const EvaluationInfo = ({ evaluation }) =>
-  <Grid fluid style={{ padding: 0 }}>
-    <Row>
-      <Col key='properties-pane' xs={ 12 } sm={ 12 } md={ 12 } lg={ 12 }>
-        <Card>
-          <CardTitle title='Client Properties' />
-          <CardText>
-            <dl className='dl-horizontal'>
-              { evaluationProps.map(evalProp =>
-                <div key={ evalProp }>
-                  <dt>{ evalProp }</dt>
-                  <dd>{ evaluation[evalProp] }</dd>
-                </div>
-              )}
-            </dl>
-          </CardText>
-        </Card>
-      </Col>
-    </Row>
-  </Grid>
+class EvaluationInfo extends Component {
+  render () {
+    const evaluation = this.props.evaluation
+    const evalValues = {}
+
+    evaluationProps.map((evalProp) => {
+      evalValues[evalProp] = evaluation[evalProp] ? evaluation[evalProp] : '-'
+      return null
+    })
+
+    evalValues.JobID = <JobLink jobId={ evaluation.JobID } />
+
+    if (evaluation.PreviousEval) {
+      evalValues.PreviousEval = <EvaluationLink evaluationId={ evaluation.PreviousEval } />
+    }
+    if (evaluation.NextEval) {
+      evalValues.NextEval = <EvaluationLink evaluationId={ evaluation.NextEval } />
+    }
+
+    return (
+      <Grid fluid style={{ padding: 0 }}>
+        <Row>
+          <Col key='properties-pane' xs={ 12 } sm={ 12 } md={ 12 } lg={ 12 }>
+            <Card>
+              <CardTitle title='Evaluation Properties' />
+              <CardText>
+                <MetaPayload metaBag={ evalValues } sortKeys={ false } />
+              </CardText>
+            </Card>
+          </Col>
+        </Row>
+      </Grid>
+    )
+  }
+}
 
 
 function mapStateToProps ({ evaluation }) {


### PR DESCRIPTION
* fix the panel title
* add missing attributes (description is cool)
* add a link towards the related job
* add links between next/previous evaluation

There's still a problem though: although the links to previous/next evaluations are correctly generated, clicking on them changes the URL but doesn't reload the page. I suspect this is due to being the same component (the `EvaluationInfo` component, but with different properties which aren't correctly loaded), but I've no idea how to fix that correctly. If any React expert is around, that would be cool to have a look :)