### PR TITLE
Update version of Consul Client API to latest, which now reads CONSUL_CACERT, CONSUL_CLIENT_CERT and CONSUL_CLIENT_KEY environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ hashi-ui can be controlled by both ENV or CLI flags as described below
 | Environment        	  |CLI (`--flag`)    	      | Default                 	| Description                                                                                                      |
 |-------------------------|---------------------------|-----------------------------|------------------------------------------------------------------------------------------------------------------|
 | `NOMAD_ENABLE`          | `nomad-enable`      	  | `false` 	                | Use `--nomad.enable` or env `NOMAD_ENABLE=1` to enable Nomad backend                                             |
-| `NOMAD_ADDR`            | `nomad-address`      	  | `http://127.0.0.1:4646` 	| Protocol + Host + Port for your .                                                                                |
+| `NOMAD_ADDR`            | `nomad-address`      	  | `http://127.0.0.1:4646` 	| Protocol + Host + Port for your Nomad instance                                                                               |
 | `NOMAD_READ_ONLY`    	  | `nomad-read-only`   	  | `false` 		        	| Should hash-ui allowed to modify Nomad state (stop/start jobs and so forth)	                                   |
 | `NOMAD_CACERT`      	  | `nomad-ca-cert`      	  | `<empty>`   	            | (optional) path to a CA Cert file (remember to use `https://` in `NOMAD_ADDR` if you enable TLS)                 |
 | `NOMAD_CLIENT_CERT`  	  | `nomad-client-cert`       | `<empty>` 	                | (optional) path to a client cert file (remember to use `https://` in `NOMAD_ADDR` if you enable TLS)             |
@@ -121,14 +121,16 @@ hashi-ui can be controlled by both ENV or CLI flags as described below
 
 | Environment        	  |CLI (`--flag`)   	      | Default                     | Description                                                                                                      |
 |-------------------------|-------------------------  |-----------------------------|------------------------------------------------------------------------------------------------------------------|
-| `CONSUL_ENABLE`         | `consul.enable`      	  | `false` 	                | Use `--consul.enable` or env `CONSUL_ENABLE=1` to enable Consul backend                                          |
-| `CONSUL_ADDR`           | `consul.address`    	  | `127.0.0.1:8500`            | Host + Port for your Consul server, e.g. localhost:8500` (Do not include protocol)                               |
-| `CONSUL_READ_ONLY`  	  | `consul.read-only`   	  | `false` 		            | Should hash-ui allowed to modify Consul state (modify KV, Services and so forth)                                 |
-| `CONSUL_ACL_TOKEN`  	  | `consul.acl-token`   	  | `<empty>` 		          	| Should hash-ui allowed to modify Consul state (modify KV, Services and so forth)                                 |
-| `CONSUL_HTTP_TOKEN`    |  `<empty>`              | `<empty>`     | The consul Token |
-| `CONSUL_HTTP_SSL_VERIFY` |  `<empty>`              | `true`     | Choose if you want your certificate is verify (Should false if you have a custom ssl certificate |
-| `CONSUL_HTTP_SSL`    |  `<empty>`              | `false`     | Enable HTTPS client to consul |
-
+| `CONSUL_ENABLE`         | `consul-enable`      	  | `false` 	                | Use `--consul-enable` or env `CONSUL_ENABLE=1` to enable Consul backend                                          |
+| `CONSUL_ADDR`           | `consul-address`    	  | `127.0.0.1:8500`            | Host + Port for your Consul server, e.g. localhost:8500` (Do not include protocol)                               |
+| `CONSUL_READ_ONLY`  	  | `consul-read-only`   	  | `false` 		            | Should hash-ui be allowed to modify Consul state (modify KV, Services and so forth)                              |
+| `CONSUL_ACL_TOKEN`  	  | `consul.acl-token`   	  | `<empty>` 		          	| The Consul access token to use (optional)                                                                        |
+| `CONSUL_HTTP_TOKEN`     | `<empty>`                 | `<empty>`                   | Synonym for `CONSUL_ACL_TOKEN`                                                                                   |
+| `CONSUL_HTTP_SSL_VERIFY`| `<empty>`                 | `true`                      | Choose if you want your certificate to be verified (Likely to choose false if you have a custom SSL certificate) |
+| `CONSUL_HTTP_SSL`       | `<empty>`                 | `false`                     | Enable HTTPS client to consul                                                                                    |
+| `CONSUL_CACERT`      	  | `<empty>`      	          | `<empty>`   	            | (optional) path to a CA Cert file (remember to set `CONSUL_HTTP_SSL` to true)                                    |
+| `CONSUL_CLIENT_CERT`    | `<empty>`                 | `<empty>` 	                | (optional) path to a client cert file (remember to set `CONSUL_HTTP_SSL` to true)                                |
+| `CONSUL_CLIENT_KEY`  	  | `<empty>`                 | `<empty>` 	                | (optional) path to a client key file (remember to set `CONSUL_HTTP_SSL` to true)          	                   |
 
 ## Instrumentation Configuration
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -111,7 +111,7 @@ func main() {
 	} else {
 		logger.Infof("| consul-read-only     : %-50s |", "No (Hashi-UI can change Consul state)")
 	}
-	logger.Infof("| consul.address       : %-50s |", cfg.ConsulAddress)
+	logger.Infof("| consul-address       : %-50s |", cfg.ConsulAddress)
 	logger.Infof("| consul.acl-token     : %-50s |", cfg.ConsulACLToken)
 
 	logger.Infof("-----------------------------------------------------------------------------")

--- a/backend/vendor/vendor.json
+++ b/backend/vendor/vendor.json
@@ -486,11 +486,11 @@
 			"revisionTime": "2016-10-29T22:21:16Z"
 		},
 		{
-			"checksumSHA1": "FXiaccMs+1NvIHh8W44lQJeGqms=",
+			"checksumSHA1": "RmhTKLvlDtxNPKZFnPYnfG/HzrI=",
 			"origin": "github.com/hashicorp/nomad/vendor/github.com/hashicorp/consul/api",
 			"path": "github.com/hashicorp/consul/api",
-			"revision": "f4a08a193d8fed7095b00c9080e09ff41cd7d4bf",
-			"revisionTime": "2017-02-11T00:41:28Z"
+			"revision": "d0abb99a6f38b8c71ef4100b7d1cbd256a5070e2",
+			"revisionTime": "2017-06-16T23:05:40Z"
 		},
 		{
 			"checksumSHA1": "0DPAA2cTBjrCGgXaxXil0vILcFs=",


### PR DESCRIPTION
It was only since [this commit](https://github.com/hashicorp/nomad/commit/78af6000704860e81edeb4b21199ee3f3ca657e9#diff-40cd17322eac38db030c42465d64597b) that the Consul GO API would retrieve CONSUL_CACERT, CONSUL_CLIENT_CERT and CONSUL_CLIENT_KEY variables from the environment and set them on the client connection. The version of this library used by hashi-ui predates this commit. By upgrading this dependency, these features can be used, allowing for certificate verification with custom SSL certificates. This fixes #234

Also, update documentation to match and fix documentation typos