### PR TITLE
Add option to use https protocol

### DIFF
--- a/backend/config.go
+++ b/backend/config.go
@@ -16,6 +16,14 @@ var (
 	flagListenAddress = flag.String("listen-address", "",
 		"The address on which to expose the web interface. "+flagDefault(defaultConfig.ListenAddress))
 
+	flagHttpsEnable = flag.Bool("https-enable", false, "Use https protocol instead. ")
+
+	flagServerCert = flag.String("server-cert", "",
+		"Server certificate to use when https protocol is enabled.")
+
+	flagServerKey = flag.String("server-key", "",
+		"Server key to use when https protocol is enabled.")
+
 	flagNewRelicAppName = flag.String("newrelic-app-name", "hashi-ui",
 		"The NewRelic app name. "+flagDefault(defaultConfig.NewRelicAppName))
 
@@ -28,6 +36,9 @@ type Config struct {
 	LogLevel      string
 	ProxyAddress  string
 	ListenAddress string
+	HttpsEnable   bool
+	ServerCert    string
+	ServerKey     string
 
 	NewRelicAppName string
 	NewRelicLicense string
@@ -100,6 +111,19 @@ func ParseAppFlagConfig(c *Config) {
 	if *flagProxyAddress != "" {
 		c.ProxyAddress = *flagProxyAddress
 	}
+
+	if *flagHttpsEnable {
+		c.HttpsEnable = *flagHttpsEnable
+	}
+
+	if *flagServerCert != "" {
+		c.ServerCert = *flagServerCert
+	}
+
+	if *flagServerKey != "" {
+		c.ServerKey = *flagServerKey
+	}
+
 }
 
 // ParseNewRelicConfig ...

--- a/backend/main.go
+++ b/backend/main.go
@@ -76,7 +76,13 @@ func main() {
 	logger.Infof("-----------------------------------------------------------------------------")
 	logger.Infof("|                             NOMAD UI                                      |")
 	logger.Infof("-----------------------------------------------------------------------------")
-	logger.Infof("| listen-address  	: http://%-43s |", cfg.ListenAddress)
+	if !cfg.HttpsEnable {
+		logger.Infof("| listen-address        : http://%-43s |", cfg.ListenAddress)
+	} else {
+		logger.Infof("| listen-address      : https://%-43s  |", cfg.ListenAddress)
+	}
+	logger.Infof("| server-certificate   	: %-50s |", cfg.ServerCert)
+	logger.Infof("| server-key       	: %-50s |", cfg.ServerKey)
 	logger.Infof("| proxy-address   	: %-50s |", cfg.ProxyAddress)
 	logger.Infof("| log-level       	: %-50s |", cfg.LogLevel)
 
@@ -210,7 +216,14 @@ func main() {
 	})
 
 	logger.Infof("Listening ...")
-	err = http.ListenAndServe(cfg.ListenAddress, router)
+	if cfg.HttpsEnable {
+		if cfg.ServerCert == "" || cfg.ServerKey == "" {
+			logger.Fatal("Using https protocol but server certificate or key were not specified.")
+		}
+		err = http.ListenAndServeTLS(cfg.ListenAddress, cfg.ServerCert, cfg.ServerKey, router)
+	} else {
+		err = http.ListenAndServe(cfg.ListenAddress, router)
+	}
 	if err != nil {
 		logger.Fatal(err)
 	}


### PR DESCRIPTION
When https protocol is used, server certificate and server key need to be specified as well.

Tests (this assumes that nomad/consul are running locally):
1. Use http protocol (default)
` $ ./hashi-ui --nomad-enable`
` $ curl -sI http://localhost:3000/nomad | head -n1`
`     HTTP/1.1 200 OK`

2. Use https protocol without specifying the server cert or server key
`   $ ./hashi-ui --nomad-enable --https-enable`

    we get an error as expected,
`     CRITI  Using https protocol but server certificate or key were not specified.`

3. Use https protocol and specifying the server cert or server key
`   $ ./hashi-ui --nomad-enable --https-enable --server-cert ~/server.crt --server-key ~/server.key`
`   $ curl -sI --cacert server.crt https://localhost:3000/nomad | head -n1`
`     HTTP/1.1 200 OK`