### PR TITLE
#263 Close timer in keepalive func

### DIFF
--- a/backend/nomad_connection.go
+++ b/backend/nomad_connection.go
@@ -290,7 +290,9 @@ func (c *NomadConnection) Handle() {
 func (c *NomadConnection) keepAlive() {
 	logger.Debugf("Starting keep-alive packer sender")
 	ticker := time.NewTicker(10 * time.Second)
-
+	defer func() {
+		ticker.Stop()
+	}()
 	for {
 		select {
 		case <-c.destroyCh:


### PR DESCRIPTION
PSA: I have zero GO knowlege.  also based off reading other GO repos like https://github.com/gorilla/websocket/blob/master/examples/chat/client.go

I can only assume that the timer is still active or running after the connection has closed.

When looking the gorilla websocket repository, I posted above, looks like they close their timers in what I can only imagine is a clean up func.

https://github.com/gorilla/websocket/blob/master/examples/chat/client.go#L85