### PR TITLE
Add missing event message fields

### DIFF
--- a/frontend/src/components/AllocationInfo/AllocationInfo.js
+++ b/frontend/src/components/AllocationInfo/AllocationInfo.js
@@ -81,8 +81,11 @@ class AllocationInfo extends Component {
                       {element.Message ||
                         element.SetupError ||
                         element.DriverError ||
+                        element.DriverMessage ||
+                        element.FailedSibling ||
                         element.KillError ||
                         element.DownloadError ||
+                        element.TaskSignal ||
                         element.ValidationError ||
                         element.VaultError ||
                         element.RestartReason ||


### PR DESCRIPTION
That fixes some of the problems expressed in #268 by adding missing event fields returned by the API, although I believe there should be a better way to do this by sharing more code with the Nomad CLI tool (see #268 for more explanations).
