### PR TITLE
Display Service port number in Service/Node card

### DIFF
--- a/frontend/src/containers/consul_nodes.js
+++ b/frontend/src/containers/consul_nodes.js
@@ -268,7 +268,11 @@ class ConsulNodes extends Component {
               let secondaryText = `Passing: ${counters.passing}`
               secondaryText += ` / Warning: ${counters.warning}`
               secondaryText += ` / Critical: ${counters.critical}`
-              secondaryText += ` / ID: ${entry.ID}`
+              secondaryText += ` | ID: ${entry.ID}`
+
+              if (entry.Port) {
+                secondaryText += ` | Port: ${entry.Port}`
+              }
 
               if (entry.Tags && entry.Tags.length > 0) {
                 secondaryText += ` | Tags: ${entry.Tags.join(", ")}`

--- a/frontend/src/containers/consul_services.js
+++ b/frontend/src/containers/consul_services.js
@@ -292,6 +292,10 @@ class ConsulServices extends Component {
               secondaryText += ` / Warning: ${counters.warning}`
               secondaryText += ` / Critical: ${counters.critical}`
 
+              if (entry.Service.Port) {
+                secondaryText += ` | Port: ${entry.Service.Port}`
+              }
+
               if (entry.Service.Tags && entry.Service.Tags.length > 0) {
                 secondaryText += ` | Tags: ${entry.Service.Tags.join(", ")}`
               }


### PR DESCRIPTION
For services which have a port number associated with them, display this information in the Consul service/node card.

This is most useful for Nomad registered services with dynamic ports

Example:
![image](https://user-images.githubusercontent.com/580744/28523038-89afe466-7072-11e7-8a73-12394e40a342.png)
