### PR TITLE
Show expanded filters; logger adjustment

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -102,7 +102,7 @@ func main() {
 	logger.Infof("| nomad-client-cert     : %-50s |", cfg.NomadClientCert)
 	logger.Infof("| nomad-client-key      : %-50s |", cfg.NomadClientKey)
 	logger.Infof("| nomad-skip-verify   	: %-50t |", cfg.NomadSkipVerify)
-	logger.Infof("| hide-env-data       	: %-50s |", cfg.NomadHideEnvData)
+	logger.Infof("| hide-env-data       	: %-50v |", cfg.NomadHideEnvData)
 	if cfg.NomadSkipVerify {
 		logger.Infof("| nomad-skip-verify     : %-50s |", "Yes")
 	} else {

--- a/frontend/src/components/AllocationList/AllocationList.js
+++ b/frontend/src/components/AllocationList/AllocationList.js
@@ -401,8 +401,7 @@ class AllocationList extends Component {
     return (
       <div>
         <Card key="filter">
-          <CardHeader title="Filter list" actAsExpander showExpandableButton />
-          <CardText expandable>
+          <CardText style={{ paddingTop: 0, paddingBottom: 0 }}>
             <Grid fluid style={{ padding: 0 }}>
               <Row>
                 {this.allocationIdFilter()}

--- a/frontend/src/containers/jobs.js
+++ b/frontend/src/containers/jobs.js
@@ -91,8 +91,7 @@ class Jobs extends Component {
     return (
       <div>
         <Card>
-          <CardHeader title="Filter list" actAsExpander showExpandableButton />
-          <CardText style={{ paddingTop: 0 }} expandable>
+          <CardText style={{ paddingTop: 0, paddingBottom: 0 }}>
             <JobStatusFilter />
             &nbsp;
             <JobTypeFilter />


### PR DESCRIPTION
* Logger adjustment (%v instead of %s for bool)
* Tried to show the filters directly, without having header saying "Filters" and having to click on it. I failed miserably trying to style this thing, so any further than lowering the top/bottom paddings, it needs some more love from someone who actually knows the js framework :D I don't have time to dig in this right now, so sorry in advance for incomplete PR.

I also noticed that in the recent build (even on master release) the NodeID filter doesn't work anymore on Allocations page, not sure if there's an issue open for it already.
