### PR TITLE
Include allocated resources in cluster and client stats

### DIFF
--- a/backend/connection.go
+++ b/backend/connection.go
@@ -318,10 +318,8 @@ func (c *connection) process(action structs.Action) {
 		c.once(nomad_nodes.NewDrain(action, c.nomadClient))
 	case nomad_nodes.Remove:
 		c.once(nomad_nodes.NewRemove(action, c.nomadClient))
-	case nomad_nodes.FetchClientStats:
-		c.once(nomad_nodes.NewStats(action, c.nomadClient))
 	case nomad_nodes.WatchStats:
-		c.watch(nomad_nodes.NewStats(action, c.nomadClient))
+		c.stream(nomad_nodes.NewStats(action, c.nomadClient))
 	case nomad_nodes.UnwatchStats:
 		c.unwatch(nomad_nodes.NewStats(action, nil))
 

--- a/backend/nomad/nodes/stats.go
+++ b/backend/nomad/nodes/stats.go
@@ -1,13 +1,14 @@
 package nodes
 
 import (
+	"time"
+
 	"github.com/hashicorp/nomad/api"
 	"github.com/jippi/hashi-ui/backend/structs"
 )
 
 const (
 	fetchedClientStats = "NOMAD_FETCHED_CLIENT_STATS"
-	FetchClientStats   = "NOMAD_FETCH_CLIENT_STATS"
 	WatchStats         = "NOMAD_WATCH_CLIENT_STATS"
 	UnwatchStats       = "NOMAD_UNWATCH_CLIENT_STATS"
 )
@@ -24,15 +25,80 @@ func NewStats(action structs.Action, client *api.Client) *stats {
 	}
 }
 
-func (w *stats) Do() (*structs.Response, error) {
-	ID := w.action.Payload.(string)
+//func (w *stats) Do() (*structs.Response, error) {
+func (w *stats) Do(send chan *structs.Action, subscribeCh chan interface{}, destroyCh chan struct{}) (*structs.Response, error) {
+	ticker := time.NewTicker(5 * time.Second) // fetch stats once in a while
+	timer := time.NewTimer(0 * time.Second)   // fetch stats right away
+	NodeID := w.action.Payload.(string)
 
-	stats, err := w.client.Nodes().Stats(ID, nil)
+	for {
+		select {
+		case <-destroyCh:
+			return nil, nil
+
+		case <-subscribeCh:
+			return nil, nil
+
+		case <-timer.C:
+			w.work(w.client, send, subscribeCh, NodeID)
+
+		case <-ticker.C:
+			w.work(w.client, send, subscribeCh, NodeID)
+		}
+	}
+}
+
+func (w *stats) work(client *api.Client, send chan *structs.Action, subscribeCh chan interface{}, NodeID string) {
+
+	stats, err := client.Nodes().Stats(NodeID, nil)
 	if err != nil {
-		return structs.NewErrorResponse(err)
+		return
 	}
 
-	return structs.NewResponse(fetchedClientStats, stats), nil
+	node, _, err := client.Nodes().Info(NodeID, nil)
+	if err != nil {
+		return
+	}
+
+	allocations, _, err := client.Nodes().Allocations(NodeID, nil)
+	if err != nil {
+		return
+	}
+
+	taksResult := &result{}
+	taksResult.CPUCores = len(stats.CPU)
+	taksResult.CPUIdleTime = 0
+	taksResult.CPUAllocatedMHz = 0
+	taksResult.CPUTotalMHz = 0
+	taksResult.MemoryUsed = 0
+	taksResult.MemoryTotal = 0
+	taksResult.MemoryAllocated = 0
+
+	for _, allocation := range allocations {
+		if allocation.ClientStatus == "running" {
+			for _, resources := range allocation.TaskResources {
+				taksResult.MemoryAllocated += int64(*resources.MemoryMB)
+				taksResult.CPUAllocatedMHz += int64(*resources.CPU)
+			}
+		}
+	}
+
+	for _, core := range stats.CPU {
+		taksResult.CPUIdleTime = taksResult.CPUIdleTime + core.Idle
+	}
+
+	taksResult.CPUTotalMHz += int64(*node.Resources.CPU)
+
+	if stats.Memory != nil {
+		taksResult.MemoryUsed = stats.Memory.Used
+		taksResult.MemoryTotal = stats.Memory.Total
+	}
+
+	taksResult.Uptime = stats.Uptime
+	taksResult.HostDiskStats = stats.DiskStats
+	taksResult.nodeStats = *stats
+
+	send <- &structs.Action{Type: fetchedClientStats, Payload: &taksResult}
 }
 
 func (w *stats) Key() string {
@@ -41,4 +107,18 @@ func (w *stats) Key() string {
 
 func (w *stats) IsMutable() bool {
 	return false
+}
+
+// result is struct for the result of a finished client statistics task
+type result struct {
+	CPUCores        int
+	CPUAllocatedMHz int64
+	CPUTotalMHz     int64
+	CPUIdleTime     float64
+	MemoryUsed      uint64
+	MemoryTotal     uint64
+	MemoryAllocated int64
+	nodeStats       api.HostStats
+	Uptime          uint64
+	HostDiskStats   []*api.HostDiskStats
 }

--- a/backend/vendor/vendor.json
+++ b/backend/vendor/vendor.json
@@ -229,7 +229,7 @@
 			"revisionTime": "2017-05-17T20:25:26Z"
 		},
 		{
-			"checksumSHA1": "qLwcuele4pa2OxBoa3Titv9Msr0=",
+			"checksumSHA1": "ZWgtYdxJbBEFnRbrdVOi7QrQVdc=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "b6e1ae21643682ce023deb8d152024597b0e9bb4",
 			"revisionTime": "2017-09-18T15:00:50Z"

--- a/frontend/src/components/ClientStats/ClientStats.js
+++ b/frontend/src/components/ClientStats/ClientStats.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types"
 import { Grid, Row, Col } from "react-flexbox-grid"
 import { connect } from "react-redux"
 import { NOMAD_WATCH_CLIENT_STATS, NOMAD_UNWATCH_CLIENT_STATS } from "../../sagas/event"
-import { green500, blue500 } from "material-ui/styles/colors"
+import { green500, blue500, amber500, yellow500 } from "material-ui/styles/colors"
 import { Card, CardTitle, CardText } from "material-ui/Card"
 import UtilizationPieChart from "../UtilizationPieChart/UtilizationPieChart"
 import DiskUtilizationTable from "../DiskUtilizationTable/DiskUtilizationTable"
@@ -11,7 +11,6 @@ import DiskUtilizationTable from "../DiskUtilizationTable/DiskUtilizationTable"
 class ClientStats extends Component {
   constructor(props) {
     super(props)
-
     if (props.node.ID) {
       this.watchForStats(props)
     }
@@ -35,14 +34,6 @@ class ClientStats extends Component {
       type: NOMAD_WATCH_CLIENT_STATS,
       payload: props.node.ID
     })
-  }
-
-  cpuUtilization(cpus) {
-    const sum = cpus.reduce((acc, cpu) => {
-      return acc + cpu.Idle
-    }, 0)
-
-    return Math.ceil(sum / cpus.length)
   }
 
   timeSince(seconds) {
@@ -76,40 +67,84 @@ class ClientStats extends Component {
   }
 
   render() {
-    if (!this.props.nodeStats.CPU) {
+    if (!this.props.nodeStats.CPUCores) {
       return <div>Loading ...</div>
     }
 
-    const CPU = this.cpuUtilization(this.props.nodeStats.CPU)
+    const AllocatedCPU = this.props.nodeStats.CPUAllocatedMHz / this.props.nodeStats.CPUTotalMHz * 100
+    const IdleCPU = this.props.nodeStats.CPUIdleTime / this.props.nodeStats.CPUCores
+    const UsedCPU = 100 - IdleCPU
+
+    let CompensatedAllocatedCPU = 0
+    let CompensatedIdleCPU = 0
+
+    let UsedCPUColor = green500
+
+    if (UsedCPU < AllocatedCPU) {
+      CompensatedAllocatedCPU = AllocatedCPU - UsedCPU
+      CompensatedIdleCPU = 100 - AllocatedCPU
+    } else { // over use of CPU
+      UsedCPUColor = amber500
+      CompensatedAllocatedCPU = 0
+      CompensatedIdleCPU =  100 - UsedCPU
+    }
+
     const cpuChart = [
       {
         name: "busy",
-        value: 100 - CPU,
-        humanValue: 100 - CPU + " %",
-        color: green500
+        value: UsedCPU,
+        humanValue: UsedCPU.toFixed(0) + " %",
+        color: UsedCPUColor
+      },
+      {
+        name: "allocated",
+        value: CompensatedAllocatedCPU,
+        humanValue: AllocatedCPU.toFixed(0) + " %",
+        color: yellow500
       },
       {
         name: "idle",
-        value: CPU,
-        humanValue: CPU + " %",
+        value: CompensatedIdleCPU,
+        humanValue: IdleCPU.toFixed(0) + " %",
         color: blue500
       }
     ]
 
-    const TotalMemory = this.props.nodeStats.Memory.Total / 1024 / 1024 / 1024
-    const UsedMemory = this.props.nodeStats.Memory.Used / 1024 / 1024 / 1024
+    const UsedMemory = this.props.nodeStats.MemoryUsed / 1024 / 1024 / 1024
+    const TotalMemory = this.props.nodeStats.MemoryTotal / 1024 / 1024 / 1024
+    const FreeMemory = TotalMemory - UsedMemory
+    const AllocatedMemory = this.props.nodeStats.MemoryAllocated / 1024
 
+    let CompensatedAllocatedMemory = 0
+    let CompensatedFreeMemory = 0
+
+    let UsedMemoryColor = green500
+
+    if (UsedMemory < AllocatedMemory) {
+      CompensatedAllocatedMemory = AllocatedMemory - UsedMemory
+      CompensatedFreeMemory = TotalMemory - AllocatedMemory
+    } else { // over use of Memory
+      UsedMemoryColor = amber500
+      CompensatedAllocatedMemory = 0
+      CompensatedFreeMemory =  TotalMemory - UsedMemory
+    }
     const memoryChart = [
       {
         name: "Used",
         value: UsedMemory,
         humanValue: UsedMemory.toFixed(2) + " GB",
-        color: green500
+        color: UsedMemoryColor
+      },
+      {
+        name: "Allocated",
+        value: CompensatedAllocatedMemory,
+        humanValue: AllocatedMemory.toFixed(2) + " GB",
+        color: yellow500
       },
       {
         name: "Available",
-        value: TotalMemory - UsedMemory,
-        humanValue: (TotalMemory - UsedMemory).toFixed(2) + " GB",
+        value: CompensatedFreeMemory,
+        humanValue: FreeMemory.toFixed(2) + " GB",
         color: blue500
       }
     ]
@@ -136,7 +171,7 @@ class ClientStats extends Component {
         </Row>
         <Row style={{ marginTop: "1rem" }}>
           <Col xs={12}>
-            <DiskUtilizationTable data={this.props.nodeStats.DiskStats} title="Disk utilization" />
+            <DiskUtilizationTable data={this.props.nodeStats.HostDiskStats} title="Disk utilization" />
           </Col>
         </Row>
       </Grid>


### PR DESCRIPTION
This PR implements showing the allocated resources in cluster and client stats.
These are the resources as defined in job under resources.

It also re-uses the timer as used by cluster stats in the client stats, as otherwise we would flood the API with the extra requests (/node/xxxx/info and /node/xxx/allocations, needed for the total CPU and the resources allocated resp.)