### PR TITLE
[WIP] ensure better cache for js assets across apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ build
 
 # Vagrant
 .vagrant
+
+.DS_Store
+stats.json

--- a/backend/main.go
+++ b/backend/main.go
@@ -192,7 +192,7 @@ func main() {
 			}
 
 			response = append(response, fmt.Sprintf("window.HASHI_ENDPOINT=%s;", endpointURL))
-			response = append(response, "window.HASHI_ASSETS_ROOT=window.HASHI_ASSETS_ROOT || window.HASHI_ENDPOINT;")
+			response = append(response, "window.HASHI_ASSETS_ROOT=window.HASHI_ASSETS_ROOT || window.HASHI_ENDPOINT")
 
 			w.Header().Set("Content-Type", "application/javascript")
 			w.Write([]byte(strings.Join(response, "\n")))

--- a/backend/main.go
+++ b/backend/main.go
@@ -163,6 +163,7 @@ func main() {
 
 		if idx := strings.Index(r.URL.Path, "config.js"); idx != -1 {
 			response := make([]string, 0)
+			response = append(response, "window.HASHI_DEV=false")
 			response = append(response, fmt.Sprintf("window.GIT_HASH='%s'", GitCommit))
 
 			response = append(response, fmt.Sprintf("window.CONSUL_ENABLED=%s", strconv.FormatBool(cfg.ConsulEnable)))

--- a/backend/main.go
+++ b/backend/main.go
@@ -186,12 +186,13 @@ func main() {
 
 			var endpointURL string
 			if cfg.ProxyAddress != "" {
-				endpointURL = fmt.Sprintf("\"%s\"", strings.TrimSuffix(cfg.ProxyAddress, "/"))
+				endpointURL = fmt.Sprintf("'%s'", strings.TrimSuffix(cfg.ProxyAddress, "/"))
 			} else {
-				endpointURL = "document.location.protocol + '//' + document.location.hostname + ':' + (window.NOMAD_ENDPOINT_PORT || document.location.port)"
+				endpointURL = "document.location.protocol + '//' + document.location.hostname + ':' + (window.HASHI_ENDPOINT_PORT || document.location.port)"
 			}
 
-			response = append(response, fmt.Sprintf("window.NOMAD_ENDPOINT=%s", endpointURL))
+			response = append(response, fmt.Sprintf("window.HASHI_WS_ENDPOINT=%s;", endpointURL))
+			response = append(response, "window.HASHI_ASSETS_ROOT=window.HASHI_ASSETS_ROOT || window.HASHI_ENDPOINT;")
 
 			w.Header().Set("Content-Type", "application/javascript")
 			w.Write([]byte(strings.Join(response, "\n")))

--- a/backend/main.go
+++ b/backend/main.go
@@ -191,7 +191,7 @@ func main() {
 				endpointURL = "document.location.protocol + '//' + document.location.hostname + ':' + (window.HASHI_ENDPOINT_PORT || document.location.port)"
 			}
 
-			response = append(response, fmt.Sprintf("window.HASHI_WS_ENDPOINT=%s;", endpointURL))
+			response = append(response, fmt.Sprintf("window.HASHI_ENDPOINT=%s;", endpointURL))
 			response = append(response, "window.HASHI_ASSETS_ROOT=window.HASHI_ASSETS_ROOT || window.HASHI_ENDPOINT;")
 
 			w.Header().Set("Content-Type", "application/javascript")

--- a/frontend/index.html.ejs
+++ b/frontend/index.html.ejs
@@ -38,7 +38,7 @@
   <% } %>
 
   <% if (htmlWebpackPlugin.options.window) { %>
-  <script src="//<%= htmlWebpackPlugin.options.window['NOMAD_ENDPOINT']%>:<%= htmlWebpackPlugin.options.window['NOMAD_ENDPOINT_PORT']%>/config.js"></script>
+  <script src="<%= htmlWebpackPlugin.options.window['HASHI_ENDPOINT']%>/config.js"></script>
   <% } else { %>
   <script type="text/javascript" src="config.js"></script>
   <% } %>
@@ -50,6 +50,7 @@
     var WebFontConfig = {
       google: { families: [ 'Roboto:400,300,500:latin' ] }
     };
+
     (function() {
       var wf = document.createElement('script');
       wf.src = 'https://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js';
@@ -61,7 +62,19 @@
     </script>
 
     <% for (var chunk in htmlWebpackPlugin.files.chunks) { %>
-    <script src="<%= htmlWebpackPlugin.files.chunks[chunk].entry %>"></script>
+        <%if (chunk != "recharts") { %>
+    <script>
+    (function() {
+        var script = document.createElement('script');
+        script.src = window.HASHI_ASSETS_ROOT + "<%= htmlWebpackPlugin.files.chunks[chunk].entry %>"
+        script.type = 'text/javascript';
+        script.async = false
+
+        var s = document.getElementsByTagName('script')[0];
+        s.parentNode.appendChild(script, s);
+    })();
+    </script>
+        <% } %>
     <% } %>
 
     <% if (htmlWebpackPlugin.options.devServer) { %>

--- a/frontend/index.html.ejs
+++ b/frontend/index.html.ejs
@@ -65,7 +65,8 @@
     <script>
     (function() {
         var script = document.createElement('script');
-        script.src = window.HASHI_ASSETS_ROOT + "<%= htmlWebpackPlugin.files.chunks[chunk].entry %>"
+        var src = window.HASHI_ASSETS_ROOT + ("/<%= htmlWebpackPlugin.files.chunks[chunk].entry %>").replace("//", "/")
+        script.src = src
         script.type = 'text/javascript';
         script.async = false
 

--- a/frontend/index.html.ejs
+++ b/frontend/index.html.ejs
@@ -62,7 +62,6 @@
     </script>
 
     <% for (var chunk in htmlWebpackPlugin.files.chunks) { %>
-        <%if (chunk != "recharts") { %>
     <script>
     (function() {
         var script = document.createElement('script');
@@ -74,7 +73,6 @@
         s.parentNode.appendChild(script, s);
     })();
     </script>
-        <% } %>
     <% } %>
 
     <% if (htmlWebpackPlugin.options.devServer) { %>

--- a/frontend/index.html.ejs
+++ b/frontend/index.html.ejs
@@ -14,9 +14,6 @@
   <link href="<%= htmlWebpackPlugin.files.css[css] %>" rel="stylesheet">
   <% } %>
 
-  <% if (htmlWebpackPlugin.options.baseHref) { %>
-  <base href="<%= htmlWebpackPlugin.options.baseHref %>" />
-  <% } %>
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black" />
@@ -42,7 +39,6 @@
   <% } else { %>
   <script type="text/javascript" src="config.js"></script>
   <% } %>
-
   <script type="text/javascript">
     document.write('<base href="' + HASHI_ASSETS_ROOT + '" />');
   </script>

--- a/frontend/index.html.ejs
+++ b/frontend/index.html.ejs
@@ -42,8 +42,15 @@
   <% } else { %>
   <script type="text/javascript" src="config.js"></script>
   <% } %>
+
+  <script type="text/javascript">
+    document.write('<base href="' + HASHI_ASSETS_ROOT + '" />');
+  </script>
 </head>
 <body>
+    <script type="text/javascript">
+        document.head.innerHTML = document.head.innerHTML + "<base href='" + HASHI_ENDPOINT + "' />";
+    </script>
     <div id="app"></div>
     <!-- This script adds the Roboto font to our project. For more detail go to this site:  http://www.google.com/fonts#UsePlace:use/Collection:Roboto:400,300,500 -->
     <script>

--- a/frontend/src/components/AllocationFiles/AllocationFiles.js
+++ b/frontend/src/components/AllocationFiles/AllocationFiles.js
@@ -249,9 +249,11 @@ class AllocationFiles extends Component {
       const a = file.IsDir ? "/" : ""
       const b = file.Name + a
       const c = file.IsDir ? "" : this.formatSizeUnits(file.Size)
-      const i = file.IsDir
-        ? <FontIcon className="material-icons">folder</FontIcon>
-        : <FontIcon className="material-icons">attachment</FontIcon>
+      const i = file.IsDir ? (
+        <FontIcon className="material-icons">folder</FontIcon>
+      ) : (
+        <FontIcon className="material-icons">attachment</FontIcon>
+      )
 
       return (
         <MenuItem
@@ -290,41 +292,45 @@ class AllocationFiles extends Component {
       fileName = "<please select a file>"
     }
 
-    const oversizedWarning = !this.props.file.Oversized
-      ? ""
-      : <span
-          style={{
-            display: "inline-block",
-            position: "relative",
-            top: 7,
-            right: 6
-          }}
-        >
-          <FontIcon className="material-icons" data-tip data-for={`tooltip-${this.props.file.File}`}>
-            report_problem
-          </FontIcon>
-          <span>
-            <ReactTooltip id={`tooltip-${this.props.file.File}`}>
-              <span className="file-size-warning">
-                The file you are trying to view is too large.<br />
-                Tailing has started from the last 250 lines. <br />
-                Please download the file for the entire contents.
-              </span>
-            </ReactTooltip>
-          </span>
+    const oversizedWarning = !this.props.file.Oversized ? (
+      ""
+    ) : (
+      <span
+        style={{
+          display: "inline-block",
+          position: "relative",
+          top: 7,
+          right: 6
+        }}
+      >
+        <FontIcon className="material-icons" data-tip data-for={`tooltip-${this.props.file.File}`}>
+          report_problem
+        </FontIcon>
+        <span>
+          <ReactTooltip id={`tooltip-${this.props.file.File}`}>
+            <span className="file-size-warning">
+              The file you are trying to view is too large.<br />
+              Tailing has started from the last 250 lines. <br />
+              Please download the file for the entire contents.
+            </span>
+          </ReactTooltip>
         </span>
+      </span>
+    )
 
     const downloadPath = `nomad/${this.props.router.params.region}/download${this.props.file.File}`
 
     const downloadBtn =
-      this.props.file.File.indexOf("<") >= 0
-        ? ""
-        : <form method="get" action={`${window.NOMAD_ENDPOINT}/${downloadPath}`}>
-            <input type="hidden" name="client" value={this.props.node.HTTPAddr} />
-            <input type="hidden" name="allocID" value={this.props.allocation.ID} />
-            {oversizedWarning}
-            <RaisedButton label="Download" type="submit" className="btn-download" />
-          </form>
+      this.props.file.File.indexOf("<") >= 0 ? (
+        ""
+      ) : (
+        <form method="get" action={`${window.HASHI_ENDPOINT}/${downloadPath}`}>
+          <input type="hidden" name="client" value={this.props.node.HTTPAddr} />
+          <input type="hidden" name="allocID" value={this.props.allocation.ID} />
+          {oversizedWarning}
+          <RaisedButton label="Download" type="submit" className="btn-download" />
+        </form>
+      )
 
     const title = (
       <span>

--- a/frontend/src/history.js
+++ b/frontend/src/history.js
@@ -1,14 +1,8 @@
 import { createHistory } from "history"
 import { useRouterHistory } from "react-router"
 
-const getBasename = function() {
-  const parser = document.createElement("a")
-  parser.href = window.HASHI_ENDPOINT
-  return parser.pathname !== "/" ? parser.pathname : ""
-}
-
 const browserHistory = useRouterHistory(createHistory)({
-  basename: getBasename()
+  basename: HASHI_ASSETS_ROOT
 })
 
 export default browserHistory

--- a/frontend/src/history.js
+++ b/frontend/src/history.js
@@ -3,12 +3,12 @@ import { useRouterHistory } from "react-router"
 
 const getBasename = function() {
   const parser = document.createElement("a")
-  parser.href = window.NOMAD_ENDPOINT
+  parser.href = window.HASHI_ENDPOINT
   return parser.pathname !== "/" ? parser.pathname : ""
 }
 
 const browserHistory = useRouterHistory(createHistory)({
-  basename: getBasename(),
+  basename: getBasename()
 })
 
 export default browserHistory

--- a/frontend/src/reducers/consul.js
+++ b/frontend/src/reducers/consul.js
@@ -19,11 +19,11 @@ import {
 export function ChangeConsulRegionReducer(state = {}, action) {
   switch (action.type) {
     case CONSUL_SET_REGION:
-      document.location.href = window.NOMAD_ENDPOINT + "/consul/" + action.payload + "/services"
+      document.location.href = window.HASHI_ENDPOINT + "/consul/" + action.payload + "/services"
       return {}
 
     case CONSUL_UNKNOWN_REGION:
-      document.location.href = window.NOMAD_ENDPOINT + "/consul"
+      document.location.href = window.HASHI_ENDPOINT + "/consul"
       return {}
   }
 

--- a/frontend/src/reducers/nomad.js
+++ b/frontend/src/reducers/nomad.js
@@ -3,11 +3,11 @@ import { NOMAD_SET_REGION, NOMAD_FETCHED_REGIONS, NOMAD_UNKNOWN_REGION } from ".
 export function ChangeNomadRegionReducer(state = {}, action) {
   switch (action.type) {
     case NOMAD_SET_REGION:
-      document.location.href = window.NOMAD_ENDPOINT + "/nomad/" + action.payload + "/cluster"
+      document.location.href = window.HASHI_ENDPOINT + "/nomad/" + action.payload + "/cluster"
       return {}
 
     case NOMAD_UNKNOWN_REGION:
-      document.location.href = window.NOMAD_ENDPOINT + "/nomad"
+      document.location.href = window.HASHI_ENDPOINT + "/nomad"
       return {}
   }
 

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -4,180 +4,245 @@ import { Router, Route, Redirect, IndexRedirect, browserHistory } from "react-ro
 import Loadable from "react-loadable"
 import App from "./components/app"
 
-const Allocation = Loadable({
-  loading: () => <div>Loading resources</div>,
+const MyLoadingComponent = props => {
+  if (props.isLoading) {
+    // While our other component is loading...
+    if (props.timedOut) {
+      // In case we've timed out loading our other component.
+      return <div>Loader timed out!</div>
+    } else if (props.pastDelay) {
+      // Display a loading screen after a set delay.
+      return <div>Loading...</div>
+    } else {
+      // Don't flash "Loading..." when we don't need to.
+      return null
+    }
+  } else if (props.error) {
+    // If we aren't loading, maybe
+    return <div>Error! Component failed to load</div>
+  } else {
+    // This case shouldn't happen... but we'll return null anyways.
+    return null
+  }
+}
+
+const NomadAllocation = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-allocation" */ "./containers/allocation")
 })
-const Allocations = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadAllocations = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-allocation-list" */ "./containers/allocations")
 })
-const AllocFiles = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadAllocationFiles = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-allocation-files" */ "./components/AllocationFiles/AllocationFiles")
 })
-const AllocInfo = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadAllocationInfo = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-allocation-info" */ "./components/AllocationInfo/AllocationInfo")
 })
-const AllocRaw = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadAllocationRaw = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-allocation-raw" */ "./components/AllocationRaw/AllocationRaw")
 })
-const AllocStats = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadAllocationStats = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-allocation-stats" */ "./components/AllocationStats/AllocationStats")
 })
-const Client = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadClient = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-client" */ "./containers/client")
 })
-const ClientAllocations = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadClientAllocations = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () =>
     import(/* webpackChunkName: "nomad-client-allocations" */ "./components/ClientAllocations/ClientAllocations")
 })
-const ClientEvaluations = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadClientEvaluations = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () =>
     import(/* webpackChunkName: "nomad-client-evaluations" */ "./components/ClientEvaluations/ClientEvaluations")
 })
-const ClientInfo = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadClientInfo = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-client-info" */ "./components/ClientInfo/ClientInfo")
 })
-const ClientRaw = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadClientRaw = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-client-raw" */ "./components/ClientRaw/ClientRaw")
 })
-const Clients = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadClients = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-clients" */ "./containers/clients")
 })
-const ClientStats = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadClientStats = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-client-stats" */ "./components/ClientStats/ClientStats")
 })
-const Cluster = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadCluster = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-cluster" */ "./containers/cluster")
 })
 const ConsulKV = Loadable({
-  loading: () => <div>Loading resources</div>,
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "consul-kv" */ "./containers/consul_kv")
 })
 const ConsulNodes = Loadable({
-  loading: () => <div>Loading resources</div>,
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "consul-nodes" */ "./containers/consul_nodes")
 })
 const ConsulServices = Loadable({
-  loading: () => <div>Loading resources</div>,
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "consul-services" */ "./containers/consul_services")
 })
-const Deployment = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadDeployment = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-deployment" */ "./containers/deployment")
 })
-const DeploymentAllocations = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadDeploymentAllocations = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () =>
     import(/* webpackChunkName: "nomad-deployment-allocations" */ "./components/DeploymentAllocations/DeploymentAllocations")
 })
-const DeploymentInfo = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadDeploymentInfo = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-deployment-info" */ "./components/DeploymentInfo/DeploymentInfo")
 })
-const DeploymentRaw = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadDeploymentRaw = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-deployment-raw" */ "./components/DeploymentRaw/DeploymentRaw")
 })
-const Deployments = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadDeployments = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-deployments" */ "./containers/deployments")
 })
-const EvalAllocations = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadEvaluationAllocations = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () =>
     import(/* webpackChunkName: "nomad-evaluation-allocation" */ "./components/EvaluationAllocations/EvaluationAllocations")
 })
-const EvalInfo = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadEvaluationInfo = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-evaluation-info" */ "./components/EvaluationInfo/EvaluationInfo")
 })
-const EvalRaw = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadEvaluationRaw = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-evaluation-raw" */ "./components/EvaluationRaw/EvaluationRaw")
 })
-const Evaluation = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadEvaluation = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-evaluation" */ "./containers/evaluation")
 })
-const Evaluations = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadEvaluations = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-evaluations" */ "./containers/evaluations")
 })
-const Job = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadJob = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-job" */ "./containers/job")
 })
-const JobAllocs = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadJobAllocations = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-job-allocations" */ "./components/JobAllocations/JobAllocations")
 })
-const JobChildren = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadJobChildren = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-job-children" */ "./components/JobChildren/JobChildren")
 })
-const JobDeployments = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadJobDeployments = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-job-deployments" */ "./components/JobDeployments/JobDeployments")
 })
-const JobEvals = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadJobEvaluations = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-job-evaluations" */ "./components/JobEvaluations/JobEvaluations")
 })
-const JobInfo = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadJobInfo = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-job-info" */ "./components/JobInfo/JobInfo")
 })
-const JobRaw = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadJobRaw = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-job-raw" */ "./components/JobRaw/JobRaw")
 })
-const Jobs = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadJobs = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-jobs" */ "./containers/jobs")
 })
-const JobTaskGroups = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadJobTaskGroups = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-job-taskgroups" */ "./components/JobTaskGroups/JobTaskGroups")
 })
-const SelectConsulRegion = Loadable({
-  loading: () => <div>Loading resources</div>,
+const ConsulSelectRegion = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "consul-select-region" */ "./containers/select_consul_region")
 })
-const SelectNomadRegion = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadSelectRegion = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-select-region" */ "./containers/select_nomad_region")
 })
-const Server = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadServer = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-server" */ "./containers/server")
 })
-const ServerInfo = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadServerInfo = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-server-info" */ "./components/ServerInfo/ServerInfo")
 })
-const ServerRaw = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadServerRaw = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-server-raw" */ "./components/ServerRaw/ServerRaw")
 })
-const Servers = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadServers = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-servers" */ "./containers/servers")
 })
-const SystemX = Loadable({
-  loading: () => <div>Loading resources</div>,
+const NomadSystem = Loadable({
+  delay: 200,
+  loading: MyLoadingComponent,
   loader: () => import(/* webpackChunkName: "nomad-system" */ "./containers/system")
 })
 
@@ -186,7 +251,7 @@ const AppRouter = ({ history }) => (
     <Route path="/" component={App}>
       <IndexRedirect to="/nomad" />
       // Consul
-      <Route path="/consul" component={SelectConsulRegion} />
+      <Route path="/consul" component={ConsulSelectRegion} />
       <Redirect from="/consul/:region" to="/consul/:region/services" />
       <Route path="/consul/:region/kv" component={ConsulKV} />
       <Route path="/consul/:region/kv/*" component={ConsulKV} />
@@ -195,70 +260,70 @@ const AppRouter = ({ history }) => (
       <Route path="/consul/:region/services" component={ConsulServices} />
       <Route path="/consul/:region/services/:name" component={ConsulServices} />
       // Nomad
-      <Route path="/nomad" component={SelectNomadRegion} />
+      <Route path="/nomad" component={NomadSelectRegion} />
       <Redirect from="/nomad/:region" to="/nomad/:region/cluster" />
-      <Route path="/nomad/:region/cluster" component={Cluster} />
+      <Route path="/nomad/:region/cluster" component={NomadCluster} />
       /* servers */
-      <Route path="/nomad/:region/servers" component={Servers} />
-      <Route path="/nomad/:region/servers/:memberId" component={Server}>
+      <Route path="/nomad/:region/servers" component={NomadServers} />
+      <Route path="/nomad/:region/servers/:memberId" component={NomadServer}>
         <IndexRedirect to="/nomad/:region/servers/:memberId/info" />
-        <Route path="/nomad/:region/servers/:memberId/info" component={ServerInfo} />
-        <Route path="/nomad/:region/servers/:memberId/raw" component={ServerRaw} />
+        <Route path="/nomad/:region/servers/:memberId/info" component={NomadServerInfo} />
+        <Route path="/nomad/:region/servers/:memberId/raw" component={NomadServerRaw} />
       </Route>
       /* jobs */
-      <Route path="/nomad/:region/jobs" component={Jobs} />
-      <Route path="/nomad/:region/jobs/:jobId" component={Job}>
+      <Route path="/nomad/:region/jobs" component={NomadJobs} />
+      <Route path="/nomad/:region/jobs/:jobId" component={NomadJob}>
         <IndexRedirect to="/nomad/:region/jobs/:jobId/info" />
-        <Route path="/nomad/:region/jobs/:jobId/info" component={JobInfo} />
-        <Route path="/nomad/:region/jobs/:jobId/allocations" component={JobAllocs} />
-        <Route path="/nomad/:region/jobs/:jobId/children" component={JobChildren} />
-        <Route path="/nomad/:region/jobs/:jobId/deployments" component={JobDeployments} />
-        <Route path="/nomad/:region/jobs/:jobId/evaluations" component={JobEvals} />
-        <Route path="/nomad/:region/jobs/:jobId/groups" component={JobTaskGroups} />
-        <Route path="/nomad/:region/jobs/:jobId/raw" component={JobRaw} />
+        <Route path="/nomad/:region/jobs/:jobId/info" component={NomadJobInfo} />
+        <Route path="/nomad/:region/jobs/:jobId/allocations" component={NomadJobAllocations} />
+        <Route path="/nomad/:region/jobs/:jobId/children" component={NomadJobChildren} />
+        <Route path="/nomad/:region/jobs/:jobId/deployments" component={NomadJobDeployments} />
+        <Route path="/nomad/:region/jobs/:jobId/evaluations" component={NomadJobEvaluations} />
+        <Route path="/nomad/:region/jobs/:jobId/groups" component={NomadJobTaskGroups} />
+        <Route path="/nomad/:region/jobs/:jobId/raw" component={NomadJobRaw} />
       </Route>
       /* clients */
-      <Route path="/nomad/:region/clients" component={Clients} />
-      <Route path="/nomad/:region/clients/:nodeId" component={Client}>
+      <Route path="/nomad/:region/clients" component={NomadClients} />
+      <Route path="/nomad/:region/clients/:nodeId" component={NomadClient}>
         <IndexRedirect to="/nomad/:region/clients/:nodeId/info" />
-        <Route path="/nomad/:region/clients/:nodeId/info" component={ClientInfo} />
-        <Route path="/nomad/:region/clients/:nodeId/stats" component={ClientStats} />
-        <Route path="/nomad/:region/clients/:nodeId/allocations" component={ClientAllocations} />
-        <Route path="/nomad/:region/clients/:nodeId/evaluations" component={ClientEvaluations} />
-        <Route path="/nomad/:region/clients/:nodeId/raw" component={ClientRaw} />
+        <Route path="/nomad/:region/clients/:nodeId/info" component={NomadClientInfo} />
+        <Route path="/nomad/:region/clients/:nodeId/stats" component={NomadClientStats} />
+        <Route path="/nomad/:region/clients/:nodeId/allocations" component={NomadClientAllocations} />
+        <Route path="/nomad/:region/clients/:nodeId/evaluations" component={NomadClientEvaluations} />
+        <Route path="/nomad/:region/clients/:nodeId/raw" component={NomadClientRaw} />
       </Route>
       /* deployments */
-      <Route path="/nomad/:region/deployments" component={Deployments} />
-      <Route path="/nomad/:region/deployments/:id" component={Deployment}>
+      <Route path="/nomad/:region/deployments" component={NomadDeployments} />
+      <Route path="/nomad/:region/deployments/:id" component={NomadDeployment}>
         <IndexRedirect to="/nomad/:region/deployments/:id/info" />
-        <Route path="/nomad/:region/deployments/:id/info" component={DeploymentInfo} />
-        <Route path="/nomad/:region/deployments/:id/allocations" component={DeploymentAllocations} />
-        <Route path="/nomad/:region/deployments/:id/raw" component={DeploymentRaw} />
+        <Route path="/nomad/:region/deployments/:id/info" component={NomadDeploymentInfo} />
+        <Route path="/nomad/:region/deployments/:id/allocations" component={NomadDeploymentAllocations} />
+        <Route path="/nomad/:region/deployments/:id/raw" component={NomadDeploymentRaw} />
       </Route>
       /* allocations */
-      <Route path="/nomad/:region/allocations" component={Allocations} />
-      <Route path="/nomad/:region/allocations/:allocId" component={Allocation}>
+      <Route path="/nomad/:region/allocations" component={NomadAllocations} />
+      <Route path="/nomad/:region/allocations/:allocId" component={NomadAllocation}>
         <IndexRedirect to="/nomad/:region/allocations/:allocId/info" />
-        <Route path="/nomad/:region/allocations/:allocId/info" component={AllocInfo} />
-        <Route path="/nomad/:region/allocations/:allocId/stats" component={AllocStats} />
+        <Route path="/nomad/:region/allocations/:allocId/info" component={NomadAllocationInfo} />
+        <Route path="/nomad/:region/allocations/:allocId/stats" component={NomadAllocationStats} />
         <Redirect
           from="/nomad/:region/allocations/:allocId/logs"
           to="/nomad/:region/allocations/:allocId/files"
           query={{ path: "/alloc/logs/" }}
         />
-        <Route path="/nomad/:region/allocations/:allocId/files" component={AllocFiles} query={{ path: "" }} />
-        <Route path="/nomad/:region/allocations/:allocId/raw" component={AllocRaw} />
+        <Route path="/nomad/:region/allocations/:allocId/files" component={NomadAllocationFiles} query={{ path: "" }} />
+        <Route path="/nomad/:region/allocations/:allocId/raw" component={NomadAllocationRaw} />
       </Route>
       /* evaluations */
-      <Route path="/nomad/:region/evaluations" component={Evaluations} />
-      <Route path="/nomad/:region/evaluations/:evalId" component={Evaluation}>
+      <Route path="/nomad/:region/evaluations" component={NomadEvaluations} />
+      <Route path="/nomad/:region/evaluations/:evalId" component={NomadEvaluation}>
         <IndexRedirect to="/nomad/:region/evaluations/:evalId/info" />
-        <Route path="/nomad/:region/evaluations/:evalId/info" component={EvalInfo} />
-        <Route path="/nomad/:region/evaluations/:evalId/allocations" component={EvalAllocations} />
-        <Route path="/nomad/:region/evaluations/:evalId/raw" component={EvalRaw} />
+        <Route path="/nomad/:region/evaluations/:evalId/info" component={NomadEvaluationInfo} />
+        <Route path="/nomad/:region/evaluations/:evalId/allocations" component={NomadEvaluationAllocations} />
+        <Route path="/nomad/:region/evaluations/:evalId/raw" component={NomadEvaluationRaw} />
       </Route>
       /* system */
-      <Route path="/nomad/:region/system" component={SystemX} />
+      <Route path="/nomad/:region/system" component={NomadSystem} />
     </Route>
   </Router>
 )

--- a/frontend/src/sagas/event.js
+++ b/frontend/src/sagas/event.js
@@ -315,7 +315,7 @@ export default function eventSaga() {
 
     const relParts = document.location.href
       // remove whatever is in the endpoint config
-      .replace(window.HASHI_ENDPOINT, "")
+      .replace(HASHI_DEV ? HASHI_ASSETS_ROOT : window.HASHI_ENDPOINT, "")
       // http://hashi-ui.service.consul:3000/nomad/region/cluster
       .split("/")
       .filter(v => v != "")

--- a/frontend/src/sagas/event.js
+++ b/frontend/src/sagas/event.js
@@ -314,6 +314,8 @@ export default function eventSaga() {
       .join("/")
 
     const relParts = document.location.href
+      // remove whatever is in the endpoint config
+      .replace(window.HASHI_WS_ENDPOINT, "")
       // http://hashi-ui.service.consul:3000/nomad/region/cluster
       .split("/")
       // ["nomad", "region", "cluster"]

--- a/frontend/src/sagas/event.js
+++ b/frontend/src/sagas/event.js
@@ -318,6 +318,7 @@ export default function eventSaga() {
       .replace(window.HASHI_ENDPOINT, "")
       // http://hashi-ui.service.consul:3000/nomad/region/cluster
       .split("/")
+      .filter(v => v != "")
       // ["nomad", "region", "cluster"]
       .slice(0, 3)
 

--- a/frontend/src/sagas/event.js
+++ b/frontend/src/sagas/event.js
@@ -315,7 +315,7 @@ export default function eventSaga() {
 
     const relParts = document.location.href
       // remove whatever is in the endpoint config
-      .replace(window.HASHI_WS_ENDPOINT, "")
+      .replace(window.HASHI_ENDPOINT, "")
       // http://hashi-ui.service.consul:3000/nomad/region/cluster
       .split("/")
       // ["nomad", "region", "cluster"]

--- a/frontend/src/sagas/event.js
+++ b/frontend/src/sagas/event.js
@@ -319,7 +319,7 @@ export default function eventSaga() {
       // http://hashi-ui.service.consul:3000/nomad/region/cluster
       .split("/")
       // ["nomad", "region", "cluster"]
-      .slice(3)
+      .slice(0, 3)
 
     // should only happen in developer mode
     if (relParts.length == 0) {

--- a/frontend/src/sagas/event.js
+++ b/frontend/src/sagas/event.js
@@ -299,37 +299,40 @@ function* events(socket) {
 
 export default function eventSaga() {
   return new Promise((resolve, reject) => {
-    const parser = document.createElement("a")
-    parser.href = window.NOMAD_ENDPOINT
+    const wsRoot = document.location.href
+      // dev mode is port 3000, replace with whatever port the backend said it want to use
+      .replace(":3333", ":" + window.HASHI_ENDPOINT_PORT)
+      // https:// would connect to wss://
+      .replace("http://", "ws://")
+      // http:// would connec to ws://
+      .replace("https://", "wss://")
+      // http://hashi-ui.service.consul:3000/nomad/region/cluster
+      .split("/")
+      // ["http":, "", "", "hashi-ui.service.consul:3000"]
+      .slice(0, 3)
+      // http://hashi-ui.service.consul:3000
+      .join("/")
 
-    const host = parser.host ? parser.host : document.location.host
-    const protocol = location.protocol === "https:" ? "wss:" : "ws:"
-    let relPath = document.location.pathname.replace(parser.pathname, "/").replace("//", "/")
-    let wsRoot = `${protocol}//${host}`
-    let wsURL = `/${parser.pathname}/ws`.replace("//", "/")
+    const relParts = document.location.href
+      // http://hashi-ui.service.consul:3000/nomad/region/cluster
+      .split("/")
+      // ["nomad", "region", "cluster"]
+      .slice(3)
 
-    // inside nomad scope
-    if (relPath.indexOf("/nomad") === 0) {
-      wsURL = wsURL + "/nomad"
-      relPath = relPath.replace("/nomad/", "").split("/")[0]
-      if (relPath) {
-        wsURL = wsURL + "/" + relPath
-      }
+    // should only happen in developer mode
+    if (relParts.length == 0) {
+      throw Error("Missing backend type in URL, please go to /nomad or /consul")
     }
 
-    // inside consul scope
-    if (relPath.indexOf("/consul") === 0) {
-      wsURL = wsURL + "/consul"
-      relPath = relPath.replace("/consul/", "").split("/")[0]
-      if (relPath) {
-        wsURL = wsURL + "/" + relPath
-      }
-    }
+    const wsPath = relParts
+      // take the two first chunks of the path
+      .splice(0, 2)
+      // remove any trailing slashes
+      .filter(v => v != "")
+      // join back to a path
+      .join("/")
 
-    // cleanup double slashes, yes, dirty hack :)
-    wsURL = wsURL.replace("//", "/")
-
-    const p = connectTo(wsRoot + wsURL)
+    const p = connectTo(wsRoot + "/ws/" + wsPath)
 
     return p
       .then(socket => {

--- a/frontend/webpack-prod.config.js
+++ b/frontend/webpack-prod.config.js
@@ -97,7 +97,7 @@ const config = {
   plugins: [
     new LodashModuleReplacementPlugin(),
     new webpack.DefinePlugin({ "process.env": { NODE_ENV: JSON.stringify("production") } }),
-    new webpack.optimize.CommonsChunkPlugin({ names: ["recharts", "vendor"], minChunks: 2 }),
+    new webpack.optimize.CommonsChunkPlugin({ names: ["recharts", "vendor", "app"], minChunks: 2 }),
     new webpack.LoaderOptionsPlugin({
       minimize: true,
       debug: false

--- a/frontend/webpack-prod.config.js
+++ b/frontend/webpack-prod.config.js
@@ -30,7 +30,7 @@ const config = {
     chunkFilename: "static/[name].[chunkhash].chunks.js",
     sourceMapFilename: "static/[name].[chunkhash].map",
     path: resolve(__dirname, "build/"),
-    publicPath: ""
+    publicPath: "/"
   },
 
   performance: {
@@ -119,19 +119,7 @@ const config = {
       favicon: "./assets/img/favicon.png",
       template: "./index.html.ejs",
       appMountId: "app",
-      production: true,
-      minify: {
-        removeComments: true,
-        collapseWhitespace: true,
-        removeRedundantAttributes: true,
-        useShortDoctype: true,
-        removeEmptyAttributes: true,
-        removeStyleLinkTypeAttributes: true,
-        keepClosingSlash: true,
-        minifyJS: true,
-        minifyCSS: true,
-        minifyURLs: true
-      }
+      production: true
     })
   ]
 }

--- a/frontend/webpack-prod.config.js
+++ b/frontend/webpack-prod.config.js
@@ -103,15 +103,11 @@ const config = {
     }),
     // specifically bundle recharts on its own
     new webpack.optimize.CommonsChunkPlugin({
-      name: "recharts",
+      async: "recharts",
       minChunks(module, count) {
         var context = module.context
         var targets = ["recharts"]
-        return (
-          context &&
-          context.indexOf("node_modules") >= 0 &&
-          targets.find(t => new RegExp("\\\\" + t + "\\\\", "i").test(context))
-        )
+        return context && context.indexOf("node_modules") >= 0 && targets.find(t => context.indexOf(t) >= 0)
       }
     }),
     new webpack.LoaderOptionsPlugin({

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -16,6 +16,7 @@ const config = {
       "webpack/hot/only-dev-server",
       "./src/main.js"
     ],
+    recharts: ["recharts"],
     vendor: [
       "core-js",
       "date-fns",
@@ -28,8 +29,7 @@ const config = {
       "react-flexbox-grid",
       "react-helmet",
       "react-tooltip"
-    ],
-    recharts: ["recharts"]
+    ]
   },
 
   output: {

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -119,11 +119,7 @@ const config = {
       minChunks(module, count) {
         var context = module.context
         var targets = ["recharts"]
-        return (
-          context &&
-          context.indexOf("node_modules") >= 0 &&
-          targets.find(t => new RegExp("\\\\" + t + "\\\\", "i").test(context))
-        )
+        return context && context.indexOf("node_modules") >= 0 && targets.find(t => context.indexOf(t) >= 0)
       }
     }),
     new webpack.LoaderOptionsPlugin({

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -16,7 +16,6 @@ const config = {
       "webpack/hot/only-dev-server",
       "./src/main.js"
     ],
-    recharts: ["recharts"],
     vendor: [
       "core-js",
       "date-fns",
@@ -29,7 +28,8 @@ const config = {
       "react-flexbox-grid",
       "react-helmet",
       "react-tooltip"
-    ]
+    ],
+    recharts: ["recharts"]
   },
 
   output: {
@@ -106,11 +106,10 @@ const config = {
   plugins: [
     new LodashModuleReplacementPlugin(),
     new webpack.DefinePlugin({ "process.env.NODE_ENV": '"development"' }),
-    new webpack.DefinePlugin({ "process.env.GO_PORT": process.env.GO_PORT || 3000 }),
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NamedModulesPlugin(),
     new webpack.NoEmitOnErrorsPlugin(),
-    new webpack.optimize.CommonsChunkPlugin({ names: ["app", "vendor", "recharts"], minChunks: 2 }),
+    new webpack.optimize.CommonsChunkPlugin({ names: ["recharts", "vendor", "app"], minChunks: 2 }),
     new webpack.LoaderOptionsPlugin({
       test: /\.js$/,
       options: {
@@ -129,8 +128,9 @@ const config = {
       favicon: "./assets/img/favicon.png",
       appMountId: "app",
       window: {
-        NOMAD_ENDPOINT: process.env.GO_HOST || "127.0.0.1",
-        NOMAD_ENDPOINT_PORT: process.env.GO_PORT || 3000
+        HASHI_ENDPOINT: "http://127.0.0.1:3000",
+        HASHI_ENDPOINT_PORT: 3000,
+        HASHI_ASSETS_ROOT: "http://127.0.0.1:3333"
       }
     })
   ]

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -130,7 +130,8 @@ const config = {
       window: {
         HASHI_ENDPOINT: "http://127.0.0.1:3000",
         HASHI_ENDPOINT_PORT: 3000,
-        HASHI_ASSETS_ROOT: "http://127.0.0.1:3333"
+        HASHI_ASSETS_ROOT: "http://127.0.0.1:3333",
+        HASHI_DEV: true
       }
     })
   ]


### PR DESCRIPTION
Previously all JS was loaded relatively from the current url, and hacked into working in the Go backend. 

The old behavior is like this

- `/nomad/region/allocations` -> `/nomad/region/allocations/vendor.js`  
- `/nomad/region/allocations/id/info` -> `/nomad/region/allocations/id/info/vendor.js`

And the new behavior is like this

- `/nomad/region/allocations` -> `/static/vendor.js`  
- `/nomad/region/allocations/id/info` -> `/static/vendor.js`

With this change, assets will always be served from `/static/vendor.js` no matter the URL you visit, significantly increasing load time when opening pages in news tabs and general navigation

This *might* break the `ProxyAddress` config behavior due to some random annoying bug somewhere