### PR TITLE
Fix extraneous overflow attribute

### DIFF
--- a/frontend/assets/hashi-ui.css
+++ b/frontend/assets/hashi-ui.css
@@ -99,7 +99,7 @@ th {
   border: 0;
   width: 100%;
   margin-bottom: 15px;
-  overflow-x: scroll;
+  overflow-x: auto;
   overflow-y: hidden;
   -ms-overflow-style: -ms-autohiding-scrollbar;
   -webkit-overflow-scrolling: touch;

--- a/frontend/src/components/MetaPayload/MetaPayload.js
+++ b/frontend/src/components/MetaPayload/MetaPayload.js
@@ -36,7 +36,7 @@ class MetaPayload extends Component {
       }
 
       meta.push(
-        <dd key={`${key}dd`} style={{ overflow: "scroll" }}>
+        <dd key={`${key}dd`} style={{ overflow: "auto" }}>
           {v}
         </dd>
       )


### PR DESCRIPTION
Latest version of Hashi-UI has lot of extraneous scrollbars which apparent under Firefox & Chrome(-ium) at least on Linux and Windows. See the attached screenshots, taken under Linux, for some examples:

![screenshot from 2017-10-13 13-12-34](https://user-images.githubusercontent.com/65311/31544618-f4c12524-b01b-11e7-9d7e-1c2994b13e99.png)
![screenshot from 2017-10-13 13-12-56](https://user-images.githubusercontent.com/65311/31544621-f7c84ed2-b01b-11e7-9764-7c5e855715f0.png)
![screenshot from 2017-10-13 13-13-06](https://user-images.githubusercontent.com/65311/31544626-fae10348-b01b-11e7-8214-20ee2aa74aa3.png)

This patch removes most of these scrollbars, while still showing it if needed, when the window becomes too small to display all the text.