### PR TITLE
When calculating Allocated RAM and CPU at cluster and client level, exclude allocations where ClientStatus is not "running" as this indicates a failed allocation

### DIFF
--- a/backend/nomad/cluster/stats.go
+++ b/backend/nomad/cluster/stats.go
@@ -150,7 +150,7 @@ func worker(payload *workerPayload) {
 			taskResult.MemoryAllocated = 0
 
 			for _, allocation := range allocations {
-				if allocation.DesiredStatus != "run" {
+				if allocation.DesiredStatus != "run" || allocation.ClientStatus != "running" {
 					continue
 				}
 

--- a/backend/nomad/nodes/stats.go
+++ b/backend/nomad/nodes/stats.go
@@ -74,7 +74,7 @@ func (w *stats) work(client *api.Client, send chan *structs.Action, subscribeCh 
 	taskResult.MemoryAllocated = 0
 
 	for _, allocation := range allocations {
-		if allocation.DesiredStatus != "run" {
+		if allocation.DesiredStatus != "run" || allocation.ClientStatus != "running" {
 			continue
 		}
 


### PR DESCRIPTION
When calculating Allocated RAM and CPU at cluster and client level, exclude allocations where ClientStatus is not "running" as this indicates a failed allocation

Fixes #361

Client stats before change:
![image](https://user-images.githubusercontent.com/580744/32519303-37e0bbac-c404-11e7-8993-477887732d18.png)

Client stats after change:
![image](https://user-images.githubusercontent.com/580744/32519210-e7440578-c403-11e7-8be3-4b7eda8cdc77.png)

Cluster stats before change:
![image](https://user-images.githubusercontent.com/580744/32519314-402851da-c404-11e7-971c-bff9f3534d13.png)

Cluster stats after change:
![image](https://user-images.githubusercontent.com/580744/32519317-438a572e-c404-11e7-88cf-bd9260ad6287.png)