### PR TITLE
added ACL token support for Nomad

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ hashi-ui can be controlled by both ENV or CLI flags as described below
 |-------------------------|---------------------------|-----------------------------|------------------------------------------------------------------------------------------------------------------|
 | `NOMAD_ENABLE`          | `nomad-enable`      	  | `false` 	                | Use `--nomad.enable` or env `NOMAD_ENABLE=1` to enable Nomad backend                                             |
 | `NOMAD_ADDR`            | `nomad-address`      	  | `http://127.0.0.1:4646` 	| Protocol + Host + Port for your Nomad instance                                                                   |
+| `NOMAD_ACL_TOKEN`  	  | `nomad-acl-token`   	  | `<empty>` 		          	| The Nomad access token to use (optional)                                                                        |
 | `NOMAD_READ_ONLY`    	  | `nomad-read-only`   	  | `false` 		        	| Should hash-ui allowed to modify Nomad state (stop/start jobs and so forth)	                                   |
 | `NOMAD_CACERT`      	  | `nomad-ca-cert`      	  | `<empty>`   	            | (optional) path to a CA Cert file (remember to use `https://` in `NOMAD_ADDR` if you enable TLS)                 |
 | `NOMAD_CLIENT_CERT`  	  | `nomad-client-cert`       | `<empty>` 	                | (optional) path to a client cert file (remember to use `https://` in `NOMAD_ADDR` if you enable TLS)             |
@@ -129,7 +130,7 @@ hashi-ui can be controlled by both ENV or CLI flags as described below
 | `CONSUL_ENABLE`         | `consul-enable`      	  | `false` 	                | Use `--consul-enable` or env `CONSUL_ENABLE=1` to enable Consul backend                                          |
 | `CONSUL_ADDR`           | `consul-address`    	  | `127.0.0.1:8500`            | Host + Port for your Consul server, e.g. localhost:8500` (Do not include protocol)                               |
 | `CONSUL_READ_ONLY`  	  | `consul-read-only`   	  | `false` 		            | Should hash-ui be allowed to modify Consul state (modify KV, Services and so forth)                              |
-| `CONSUL_ACL_TOKEN`  	  | `consul.acl-token`   	  | `<empty>` 		          	| The Consul access token to use (optional)                                                                        |
+| `CONSUL_ACL_TOKEN`  	  | `consul-acl-token`   	  | `<empty>` 		          	| The Consul access token to use (optional)                                                                        |
 | `CONSUL_HTTP_TOKEN`     | `<empty>`                 | `<empty>`                   | Synonym for `CONSUL_ACL_TOKEN`                                                                                   |
 | `CONSUL_HTTP_SSL_VERIFY`| `<empty>`                 | `true`                      | Choose if you want your certificate to be verified (Likely to choose false if you have a custom SSL certificate) |
 | `CONSUL_HTTP_SSL`       | `<empty>`                 | `false`                     | Enable HTTPS client to consul                                                                                    |

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -25,6 +25,9 @@ var (
 	flagNomadAddress = flag.String("nomad-address", "", "The address of the Nomad server. "+
 		"Overrides the NOMAD_ADDR environment variable if set. "+FlagDefault(defaultConfig.NomadAddress))
 
+	flagNomadACLToken = flag.String("nomad-acl-token", "", "An ACL token to use when talking to Nomad. "+
+		"Overrides the NOMAD_ACL_TOKEN environment variable if set. "+FlagDefault(defaultConfig.NomadACLToken))
+
 	flagNomadCACert = flag.String("nomad-ca-cert", "", "Path to the Nomad TLS CA Cert File. "+
 		"Overrides the NOMAD_CACERT environment variable if set. "+FlagDefault(defaultConfig.NomadCACert))
 
@@ -48,7 +51,7 @@ var (
 	flagConsulAddress = flag.String("consul-address", "", "The address of the Consul server. "+
 		"Overrides the CONSUL_ADDR environment variable if set. "+FlagDefault(defaultConfig.ConsulAddress))
 
-	flagConsulACLToken = flag.String("consul.acl-token", "", "A ACL token to use when talking to Consul. "+
+	flagConsulACLToken = flag.String("consul-acl-token", "", "An ACL token to use when talking to Consul. "+
 		"Overrides the CONSUL_ACL_TOKEN environment variable if set. "+FlagDefault(defaultConfig.ConsulACLToken))
 
 	flagLogLevel = flag.String("log-level", "",
@@ -88,6 +91,7 @@ type Config struct {
 
 	NomadEnable      bool
 	NomadAddress     string
+	NomadACLToken    string
 	NomadCACert      string
 	NomadClientCert  string
 	NomadClientKey   string
@@ -238,6 +242,11 @@ func ParseNomadEnvConfig(c *Config) {
 		c.NomadAddress = nomadAddress
 	}
 
+	nomadAclToken, ok := syscall.Getenv("NOMAD_ACL_TOKEN")
+	if ok {
+		c.NomadACLToken = nomadAclToken
+	}
+
 	listenPort, ok := syscall.Getenv("NOMAD_PORT_http")
 	if ok {
 		c.ListenAddress = fmt.Sprintf("0.0.0.0:%s", listenPort)
@@ -303,6 +312,10 @@ func ParseNomadFlagConfig(c *Config) {
 		c.NomadAddress = *flagNomadAddress
 	}
 
+	if *flagNomadACLToken != "" {
+		c.NomadACLToken = *flagNomadACLToken
+	}
+
 	if *flagNomadCACert != "" {
 		c.NomadCACert = *flagNomadCACert
 	}
@@ -341,9 +354,9 @@ func ParseConsulEnvConfig(c *Config) {
 		c.ConsulAddress = consulAddress
 	}
 
-	aclToken, ok := syscall.Getenv("CONSUL_ACL_TOKEN")
+	consulAclToken, ok := syscall.Getenv("CONSUL_ACL_TOKEN")
 	if ok {
-		c.ConsulACLToken = aclToken
+		c.ConsulACLToken = consulAclToken
 	}
 
 	consulColor, ok := syscall.Getenv("CONSUL_COLOR")

--- a/backend/main.go
+++ b/backend/main.go
@@ -57,6 +57,7 @@ func main() {
 		log.Infof("| nomad-read-only      : %-50s |", "No (Hashi-UI can change Nomad state)")
 	}
 	log.Infof("| nomad-address        : %-50s |", cfg.NomadAddress)
+	log.Infof("| nomad-acl-token     : %-50s |", cfg.NomadACLToken)
 	log.Infof("| nomad-ca-cert        : %-50s |", cfg.NomadCACert)
 	log.Infof("| nomad-client-cert    : %-50s |", cfg.NomadClientCert)
 	log.Infof("| nomad-client-key     : %-50s |", cfg.NomadClientKey)
@@ -82,7 +83,7 @@ func main() {
 		log.Infof("| consul-read-only     : %-50s |", "No (Hashi-UI can change Consul state)")
 	}
 	log.Infof("| consul-address       : %-50s |", cfg.ConsulAddress)
-	log.Infof("| consul.acl-token     : %-50s |", cfg.ConsulACLToken)
+	log.Infof("| consul-acl-token     : %-50s |", cfg.ConsulACLToken)
 	log.Infof("| consul-color         : %-50s |", cfg.ConsulColor)
 
 	log.Infof("-----------------------------------------------------------------------------")

--- a/backend/nomad/helper/helper.go
+++ b/backend/nomad/helper/helper.go
@@ -11,6 +11,7 @@ import (
 func NewRegionClient(c *config.Config, region string) (*api.Client, error) {
 	config := api.DefaultConfig()
 	config.Address = c.NomadAddress
+	config.SecretID = c.NomadACLToken
 	config.WaitTime = 1 * time.Minute
 	config.Region = region
 	config.TLSConfig = &api.TLSConfig{


### PR DESCRIPTION
This PR is intended to resolve #376. I added support for Nomad ACL tokens, based on what's already implemented for Consul ACL. I also renamed the consul ACL token argument from `consul.acl-token` to `consul-acl-token` to keep the naming convention consistent with other arguments.