### PR TITLE
Add a config attribute for Nomad region.

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -42,6 +42,9 @@ var (
 	flagNomadAllowStale = flag.Bool("nomad-allow-stale", true, "Whether Hashi-UI should use stale mode when connecting to the nomad-api servers"+
 		"Overrides the NOMAD_ALLOW_STALE environment variable if set. "+FlagDefault(strconv.FormatBool(defaultConfig.NomadAllowStale)))
 
+    flagNomadRegion = flag.String("nomad-region", "", "Always show the given region and disable the region selector. "+
+        "Overrides the NOMAD_REGION environment variable if set. "+FlagDefault(defaultConfig.NomadRegion))
+
 	flagConsulEnable = flag.Bool("consul-enable", false, "Whether Consul engine should be started. "+
 		"Overrides the CONSUL_ENABLE environment variable if set. "+FlagDefault(strconv.FormatBool(defaultConfig.ConsulEnable)))
 
@@ -99,6 +102,7 @@ type Config struct {
 	NomadSkipVerify  bool
 	NomadHideEnvData bool
 	NomadAllowStale  bool
+    NomadRegion      string
 	NomadColor       string
 
 	ConsulEnable   bool
@@ -284,6 +288,11 @@ func ParseNomadEnvConfig(c *Config) {
 		c.NomadAllowStale = nomadAllowStale != "true"
 	}
 
+    nomadRegion, ok := syscall.Getenv("NOMAD_REGION")
+    if ok {
+        c.NomadRegion = nomadRegion
+    }
+
 	nomadColor, ok := syscall.Getenv("NOMAD_COLOR")
 	if ok {
 		c.NomadColor = nomadColor
@@ -331,6 +340,10 @@ func ParseNomadFlagConfig(c *Config) {
 	if *flagNomadAllowStale {
 		c.NomadAllowStale = *flagNomadAllowStale
 	}
+
+    if *flagNomadRegion != "" {
+        c.NomadRegion = *flagNomadRegion
+    }
 
 	if *flagNomadColor != "" {
 		c.NomadColor = *flagNomadColor

--- a/backend/main.go
+++ b/backend/main.go
@@ -73,6 +73,9 @@ func main() {
 	} else {
 		log.Infof("| nomad-allow-stale    : %-50s |", "No")
 	}
+	if cfg.NomadRegion != "" {
+		log.Infof("| nomad-region         : %-50s |", cfg.NomadRegion)
+	}
 	log.Infof("| nomad-color          : %-50s |", cfg.NomadColor)
 
 	// Consul
@@ -131,9 +134,16 @@ func main() {
 	// setup http handlers
 
 	if cfg.NomadEnable {
+		var regionPath string
+
 		router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-			log.Infof("Redirecting / to /nomad")
-			w.Write([]byte("<script>document.location.href='" + cfg.ProxyPath + "nomad'</script>"))
+			if cfg.NomadRegion != "" {
+				regionPath = "/" + cfg.NomadRegion
+			} else {
+				regionPath = ""
+			}
+			log.Infof("Redirecting / to /nomad" + regionPath)
+			w.Write([]byte("<script>document.location.href='" + cfg.ProxyPath + "nomad" + regionPath + "'</script>"))
 			return
 		})
 


### PR DESCRIPTION
This is an attempt to implement #384. It adds a new config attribute that allows the operator to set a particular Nomad region for the UI to display. If set, and a user visits the root path, they are redirected to the region's page instead of the region picker.