### PR TITLE
feat: enable feature to throttle requests when watching consul/nomad resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,15 +98,16 @@ hashi-ui can be controlled by both ENV or CLI flags as described below
 
 ## General Configuration
 
-| Environment        	  |CLI (`--flag`)            | Default                 	    | Description                                                                                                      |
-|-------------------------|---------------------------|---------------------------- |------------------------------------------------------------------------------------------------------------------|
-| `LOG_LEVEL` 	          | `log-level`               | `info`                  	| Log level to use while running the hashi-ui server - (`critical`, `error`, `warning`, `notice`, `info`, `debug`) |
-| `PROXY_ADDRESS`         | `proxy-address` 	      | `<empty>`               	| (optional) The base URL of the UI when running behind a reverse proxy (ie: example.com/nomad/)                   |
-| `LISTEN_ADDRESS`        | `listen-address`          | `0.0.0.0:3000`              | The IP + PORT to listen on |
-| `HTTPS_ENABLE`          | `https-enable`            | `false`                     | Use HTTPS instead of HTTP for Hashi-UI |
-| `SERVER_CERT`           | `server-cert`             | `<empty>`                   | Server certificate to use when HTTPS is enabled |
-| `SERVER_KEY`            | `server-key`              | `<empty>`                   | Server key to use when HTTPS is enabled |
-| `SITE_TITLE`            | `site-title`              | `<empty>`                   | Free-form text to be prepended to title-bar; eg. "Staging" |
+| Environment        	       | CLI (`--flag`)              | Default                 	    | Description                                                                                                      |
+|----------------------------|-----------------------------|---------------------------- |------------------------------------------------------------------------------------------------------------------|
+| `LOG_LEVEL` 	             | `log-level`                 | `info`                  	| Log level to use while running the hashi-ui server - (`critical`, `error`, `warning`, `notice`, `info`, `debug`) |
+| `PROXY_ADDRESS`            | `proxy-address` 	           | `<empty>`               	| (optional) The base URL of the UI when running behind a reverse proxy (ie: example.com/nomad/)                   |
+| `LISTEN_ADDRESS`           | `listen-address`            | `0.0.0.0:3000`              | The IP + PORT to listen on |
+| `HTTPS_ENABLE`             | `https-enable`              | `false`                     | Use HTTPS instead of HTTP for Hashi-UI |
+| `SERVER_CERT`              | `server-cert`               | `<empty>`                   | Server certificate to use when HTTPS is enabled |
+| `SERVER_KEY`               | `server-key`                | `<empty>`                   | Server key to use when HTTPS is enabled |
+| `SITE_TITLE`               | `site-title`                | `<empty>`                   | Free-form text to be prepended to title-bar; eg. "Staging" |
+| `UPDATE_THROTTLE_DURATION` | `throttle-update-duration`  | `<empty>`                   | Duration to sleep before polling Nomad/Consul for updates. Useful in busy clusters ([example: `5s`, `250ms`](https://golang.org/pkg/time/#ParseDuration)) |
 
 ## Nomad Configuration
 

--- a/backend/connection.go
+++ b/backend/connection.go
@@ -451,7 +451,7 @@ func (c *connection) watch(w subscriber.Watcher) {
 		return
 	}
 
-	go subscriber.Watch(w, c.subscriptions, c.logger, c.sendCh, c.destroyCh)
+	go subscriber.Watch(w, c.subscriptions, c.logger, c.config, c.sendCh, c.destroyCh)
 }
 
 // once will start a one-off execution of a watcher in a new Go routine

--- a/backend/main.go
+++ b/backend/main.go
@@ -18,6 +18,7 @@ import (
 
 var (
 	GitCommit string // Filled in by the compiler
+	AppConfig *config.Config
 )
 
 func startLogging(logLevel string) {
@@ -34,60 +35,68 @@ func main() {
 	cfg := config.DefaultConfig()
 	cfg.Parse()
 
+	AppConfig = cfg
+
 	startLogging(cfg.LogLevel)
 
-	log.Infof("-----------------------------------------------------------------------------")
-	log.Infof("|                             HASHI UI                                      |")
-	log.Infof("-----------------------------------------------------------------------------")
+	log.Infof("----------------------------------------------------------------------------------")
+	log.Infof("|                                 HASHI UI                                       |")
+	log.Infof("----------------------------------------------------------------------------------")
 	if !cfg.HttpsEnable {
-		log.Infof("| listen-address       : http://%-43s |", cfg.ListenAddress)
+		log.Infof("| listen-address            : http://%-43s |", cfg.ListenAddress)
 	} else {
-		log.Infof("| listen-address      : https://%-43s  |", cfg.ListenAddress)
+		log.Infof("| listen-address            : https://%-43s  |", cfg.ListenAddress)
 	}
-	log.Infof("| server-certificate   : %-50s |", cfg.ServerCert)
-	log.Infof("| server-key       	  : %-50s |", cfg.ServerKey)
-	log.Infof("| site-title       	  : %-50s |", cfg.SiteTitle)
-	log.Infof("| proxy-address   	  : %-50s |", cfg.ProxyAddress)
-	log.Infof("| log-level       	  : %-50s |", cfg.LogLevel)
+	log.Infof("| server-certificate        : %-50s |", cfg.ServerCert)
+	log.Infof("| server-key       	       : %-50s |", cfg.ServerKey)
+	log.Infof("| site-title       	       : %-50s |", cfg.SiteTitle)
+	log.Infof("| proxy-address   	       : %-50s |", cfg.ProxyAddress)
+	log.Infof("| log-level       	       : %-50s |", cfg.LogLevel)
+
+	if cfg.ThrottleUpdateDuration != nil {
+		log.Infof("| throttle-update-duration  : %-50s |", cfg.ThrottleUpdateDuration)
+	} else {
+		log.Infof("| throttle-update-duration  : %-50s |", "0s")
+	}
 
 	// Nomad
-	log.Infof("| nomad-enable     	  : %-50t |", cfg.NomadEnable)
+	log.Infof("| nomad-enable     	       : %-50t |", cfg.NomadEnable)
 	if cfg.NomadReadOnly {
-		log.Infof("| nomad-read-only      : %-50s |", "Yes")
+		log.Infof("| nomad-read-only           : %-50s |", "Yes")
 	} else {
-		log.Infof("| nomad-read-only      : %-50s |", "No (Hashi-UI can change Nomad state)")
+		log.Infof("| nomad-read-only           : %-50s |", "No (Hashi-UI can change Nomad state)")
 	}
-	log.Infof("| nomad-address        : %-50s |", cfg.NomadAddress)
-	log.Infof("| nomad-acl-token     : %-50s |", cfg.NomadACLToken)
-	log.Infof("| nomad-ca-cert        : %-50s |", cfg.NomadCACert)
-	log.Infof("| nomad-client-cert    : %-50s |", cfg.NomadClientCert)
-	log.Infof("| nomad-client-key     : %-50s |", cfg.NomadClientKey)
-	log.Infof("| nomad-skip-verify    : %-50t |", cfg.NomadSkipVerify)
-	log.Infof("| nomad-hide-env-data  : %-50v |", cfg.NomadHideEnvData)
+	log.Infof("| nomad-address             : %-50s |", cfg.NomadAddress)
+	log.Infof("| nomad-acl-token           : %-50s |", cfg.NomadACLToken)
+	log.Infof("| nomad-ca-cert             : %-50s |", cfg.NomadCACert)
+	log.Infof("| nomad-client-cert         : %-50s |", cfg.NomadClientCert)
+	log.Infof("| nomad-client-key          : %-50s |", cfg.NomadClientKey)
+	log.Infof("| nomad-skip-verify         : %-50t |", cfg.NomadSkipVerify)
+	log.Infof("| nomad-hide-env-data       : %-50v |", cfg.NomadHideEnvData)
 	if cfg.NomadSkipVerify {
-		log.Infof("| nomad-skip-verify    : %-50s |", "Yes")
+		log.Infof("| nomad-skip-verify         : %-50s |", "Yes")
 	} else {
-		log.Infof("| nomad-skip-verify    : %-50s |", "No")
+		log.Infof("| nomad-skip-verify         : %-50s |", "No")
 	}
 	if cfg.NomadAllowStale {
-		log.Infof("| nomad-allow-stale    : %-50s |", "Yes")
+		log.Infof("| nomad-allow-stale         : %-50s |", "Yes")
 	} else {
-		log.Infof("| nomad-allow-stale    : %-50s |", "No")
+		log.Infof("| nomad-allow-stale         : %-50s |", "No")
 	}
-	log.Infof("| nomad-color          : %-50s |", cfg.NomadColor)
+	log.Infof("| nomad-color               : %-50s |", cfg.NomadColor)
 
 	// Consul
-	log.Infof("| consul-enable     	  : %-50t |", cfg.ConsulEnable)
+	log.Infof("| consul-enable     	       : %-50t |", cfg.ConsulEnable)
 	if cfg.ConsulReadOnly {
-		log.Infof("| consul-read-only     : %-50s |", "Yes")
+		log.Infof("| consul-read-only          : %-50s |", "Yes")
 	} else {
-		log.Infof("| consul-read-only     : %-50s |", "No (Hashi-UI can change Consul state)")
+		log.Infof("| consul-read-only          : %-50s |", "No (Hashi-UI can change Consul state)")
 	}
-	log.Infof("| consul-address       : %-50s |", cfg.ConsulAddress)
-	log.Infof("| consul-acl-token     : %-50s |", cfg.ConsulACLToken)
-	log.Infof("| consul-color         : %-50s |", cfg.ConsulColor)
+	log.Infof("| consul-address            : %-50s |", cfg.ConsulAddress)
+	log.Infof("| consul-acl-token          : %-50s |", cfg.ConsulACLToken)
+	log.Infof("| consul-color              : %-50s |", cfg.ConsulColor)
 
-	log.Infof("-----------------------------------------------------------------------------")
+	log.Infof("----------------------------------------------------------------------------------")
 	log.Infof("")
 
 	if !cfg.NomadEnable && !cfg.ConsulEnable {


### PR DESCRIPTION
Super useful in busy clusters where changes happen all the time, which cause a ton of CPU, Memory and Network traffic without much win for the end user 

Signed-off-by: Christian Winther <jippignu@gmail.com>