### PR TITLE
Fix proxied websocket routing

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -104,7 +104,7 @@ func main() {
 	}
 
 	myAssetFS := assetFS()
-	router := mux.NewRouter()
+	router := mux.NewRouter().PathPrefix(cfg.ProxyPath).Subrouter()
 
 	// create clients
 	var nomadClient *nomad.Client


### PR DESCRIPTION
While attempting to get `hashi-ui` working behind `fabio` under a proxied path, I realised that while `PROXY_ADDRESS` affects the frontend and redirects correctly, it has no effect on the routes in the backend.

This means that you could set `PROXY_ADDRESS=/ui` but you would still need to proxy `/ws` to `hashi-ui` as well.

This commit moves all existing routes into a Subrouter, and prefixes the main router with whatever is in `ProxyPath` (which defaults to `/` so has no effect if `PROXY_ADDRESS` is not given)

Setting `PROXY_ADDRESS=/ui` will now make the websocket paths available on `/ui/ws/{nomad,consul}` etc instead of `/ws/...`

Could be a better way to do this but I'm not familiar with `gorilla/mux` so... suggestions welcome!

