### PR TITLE
Virtualize job list rendering

### DIFF
--- a/frontend/src/components/JobList/JobList.js
+++ b/frontend/src/components/JobList/JobList.js
@@ -39,7 +39,7 @@ const JobTypeCell = ({ rowIndex, data: jobs, ... props }) => {
   const job = jobs[rowIndex];
   return (
     <Cell {...props}>
-      <JobLink jobId={job.Type} />
+      {job.Type}
     </Cell>
   )
 }
@@ -48,7 +48,7 @@ const JobPriorityCell = ({ rowIndex, data: jobs, ... props }) => {
   const job = jobs[rowIndex];
   return (
     <Cell {...props}>
-      <JobLink jobId={job.Priority} />
+      {job.Priority}
     </Cell>
   )
 }
@@ -57,7 +57,7 @@ const JobStatusCell = ({ rowIndex, data: jobs, ... props }) => {
   const job = jobs[rowIndex];
   return (
     <Cell {...props}>
-      <JobLink jobId={job.Status} />
+      {job.Status}
     </Cell>
   )
 }

--- a/frontend/src/components/JobList/JobList.js
+++ b/frontend/src/components/JobList/JobList.js
@@ -114,7 +114,28 @@ const JobNumLostCell = ({ rowIndex, data: jobs, ... props }) => {
 
 
 class JobList extends Component {
+  updateDimensions = () => {
+    this.setState({
+      width: window.innerWidth,
+      height: window.innerHeight
+    })
+  }
+
+  componentWillMount = () => {
+    this.updateDimensions()
+  }
+
+  componentDidMount = () => {
+    window.addEventListener("resize", this.resizeHandler)
+  }
+
+  componentWillUnmount = () => {
+    window.removeEventListener("resize", this.resizeHandler)
+  }
+
   render() {
+    const width = this.state.width - 240;
+    const height = Math.max(this.state.height - 165, 300)
     return (
       <Table>
         <TableHeader>

--- a/frontend/src/components/JobList/JobList.js
+++ b/frontend/src/components/JobList/JobList.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react"
 import PropTypes from "prop-types"
 import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColumn } from "../Table"
+import { Cell } from "fixed-data-table-2";
 import JobLink from "../JobLink/JobLink"
 import AllocationDistribution from "../AllocationDistribution/AllocationDistribution"
 import JobHealth from "../JobHealth/JobHealth"
@@ -38,6 +39,79 @@ const failedTaskCount = job => {
 
   return counter
 }
+
+const JobNameCell = ({ rowIndex, data: jobs, ... props }) => {
+  const job = jobs[rowIndex];
+  return (
+    <Cell {...props}>
+      <JobLink jobId={job.ID} />
+    </Cell>
+  )
+}
+
+const JobTypeCell = ({ rowIndex, data: jobs, ... props }) => {
+  const job = jobs[rowIndex];
+  return (
+    <Cell {...props}>
+      <JobLink jobId={job.Type} />
+    </Cell>
+  )
+}
+
+const JobPriorityCell = ({ rowIndex, data: jobs, ... props }) => {
+  const job = jobs[rowIndex];
+  return (
+    <Cell {...props}>
+      <JobLink jobId={job.Priority} />
+    </Cell>
+  )
+}
+
+const JobStatusCell = ({ rowIndex, data: jobs, ... props }) => {
+  const job = jobs[rowIndex];
+  return (
+    <Cell {...props}>
+      <JobLink jobId={job.Status} />
+    </Cell>
+  )
+}
+
+const JobInSyncCell = ({ rowIndex, data: jobs, ... props }) => {
+  const job = jobs[rowIndex];
+  return (
+    <Cell {...props}>
+      {job.Type == "service" ? <JobHealth jobID={job.ID} /> : null}
+    </Cell>
+  )
+}
+
+const JobGroupsCell = ({ rowIndex, data: jobs, ... props }) => {
+  const job = jobs[rowIndex];
+  return (
+    <Cell {...props}>
+      {taskGroupCount(job)}
+    </Cell>
+  )
+}
+
+const JobAllocationStatusCell = ({ rowIndex, data: jobs, ... props }) => {
+  const job = jobs[rowIndex];
+  return (
+    <Cell {...props}>
+      <AllocationDistribution jobID={job.ID} summary={job.JobSummary.Summary} />
+    </Cell>
+  )
+}
+
+const JobNumLostCell = ({ rowIndex, data: jobs, ... props }) => {
+  const job = jobs[rowIndex];
+  return (
+    <Cell {...props}>
+      {this.failedTaskCount(job)}
+    </Cell>
+  )
+}
+
 
 class JobList extends Component {
   render() {

--- a/frontend/src/components/JobList/JobList.js
+++ b/frontend/src/components/JobList/JobList.js
@@ -20,28 +20,28 @@ const flexibleWidth = {
 
 const summaryLabels = ["Starting", "Running", "Queued", "Complete", "Failed", "Lost"]
 
-class JobList extends Component {
-  taskGroupCount(job) {
+const taskGroupCount = job => {
     if (job.JobSummary !== null) {
       return Object.keys(job.JobSummary.Summary).length
     }
 
     return "N/A"
+}
+
+const failedTaskCount = job => {
+  let counter = 0
+
+  if (job.JobSummary !== null) {
+    const summary = job.JobSummary.Summary
+    Object.keys(job.JobSummary.Summary).forEach(taskGroupID => {
+      counter += summary[taskGroupID].Lost
+    })
   }
 
-  failedTaskCount(job) {
-    let counter = 0
+  return counter
+}
 
-    if (job.JobSummary !== null) {
-      const summary = job.JobSummary.Summary
-      Object.keys(job.JobSummary.Summary).forEach(taskGroupID => {
-        counter += summary[taskGroupID].Lost
-      })
-    }
-
-    return counter
-  }
-
+class JobList extends Component {
   render() {
     return (
       <Table>
@@ -69,11 +69,11 @@ class JobList extends Component {
                 <TableRowColumn style={columnFormat}>
                   {job.Type == "service" ? <JobHealth jobID={job.ID} /> : null}
                 </TableRowColumn>
-                <TableRowColumn style={columnFormat}>{this.taskGroupCount(job)}</TableRowColumn>
+                <TableRowColumn style={columnFormat}>{taskGroupCount(job)}</TableRowColumn>
                 <TableRowColumn style={flexibleWidth} key={`${job.ID}-statistics`}>
                   <AllocationDistribution jobID={job.ID} summary={job.JobSummary.Summary} />
                 </TableRowColumn>
-                <TableRowColumn style={columnFormat}>{this.failedTaskCount(job)}</TableRowColumn>
+                <TableRowColumn style={columnFormat}>{failedTaskCount(job)}</TableRowColumn>
               </TableRow>
           })}
         </TableBody>

--- a/frontend/src/components/JobList/JobList.js
+++ b/frontend/src/components/JobList/JobList.js
@@ -1,23 +1,9 @@
 import React, { Component } from "react"
 import PropTypes from "prop-types"
-import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColumn } from "../Table"
-import { Cell } from "fixed-data-table-2";
+import { Cell, Column, Table } from "fixed-data-table-2";
 import JobLink from "../JobLink/JobLink"
 import AllocationDistribution from "../AllocationDistribution/AllocationDistribution"
 import JobHealth from "../JobHealth/JobHealth"
-
-const columnFormat = {
-  width: 50,
-  maxWidth: 50,
-  overflow: "inherit",
-  whiteSpace: "normal"
-}
-const flexibleWidth = {
-  width: 300,
-  minWidth: 300,
-  overflow: "display",
-  whiteSpace: "normal"
-}
 
 const taskGroupCount = job => {
     if (job.JobSummary !== null) {
@@ -112,6 +98,18 @@ const JobNumLostCell = ({ rowIndex, data: jobs, ... props }) => {
   )
 }
 
+const fixedProps = {
+  width: 50,
+  maxWidth: 50,
+  flexGrow: 1
+}
+
+const flexProps = {
+  width: 300,
+  minWidth: 300,
+  flexGrow: 2
+}
+
 
 class JobList extends Component {
   updateDimensions = () => {
@@ -136,40 +134,25 @@ class JobList extends Component {
   render() {
     const width = this.state.width - 240;
     const height = Math.max(this.state.height - 165, 300)
+    const jobs = this.props.jobs;
     return (
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHeaderColumn style={flexibleWidth}>Name</TableHeaderColumn>
-            <TableHeaderColumn style={columnFormat}>Type</TableHeaderColumn>
-            <TableHeaderColumn style={columnFormat}>Priority</TableHeaderColumn>
-            <TableHeaderColumn style={columnFormat}>Status</TableHeaderColumn>
-            <TableHeaderColumn style={columnFormat}>In Sync</TableHeaderColumn>
-            <TableHeaderColumn style={columnFormat}>Groups</TableHeaderColumn>
-            <TableHeaderColumn style={flexibleWidth}>Allocation Status</TableHeaderColumn>
-            <TableHeaderColumn style={columnFormat}># Lost</TableHeaderColumn>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {this.props.jobs.map(job => {
-            return <TableRow key={job.ID}>
-                <TableRowColumn style={flexibleWidth}>
-                  <JobLink jobId={job.ID} />
-                </TableRowColumn>
-                <TableRowColumn style={columnFormat}>{job.Type}</TableRowColumn>
-                <TableRowColumn style={columnFormat}>{job.Priority}</TableRowColumn>
-                <TableRowColumn style={columnFormat}>{job.Status}</TableRowColumn>
-                <TableRowColumn style={columnFormat}>
-                  {job.Type == "service" ? <JobHealth jobID={job.ID} /> : null}
-                </TableRowColumn>
-                <TableRowColumn style={columnFormat}>{taskGroupCount(job)}</TableRowColumn>
-                <TableRowColumn style={flexibleWidth} key={`${job.ID}-statistics`}>
-                  <AllocationDistribution jobID={job.ID} summary={job.JobSummary.Summary} />
-                </TableRowColumn>
-                <TableRowColumn style={columnFormat}>{failedTaskCount(job)}</TableRowColumn>
-              </TableRow>
-          })}
-        </TableBody>
+      <Table
+        key="table"
+        rowHeight={35}
+        headerHeight={35}
+        rowsCount={jobs.length}
+        height={height}
+        width={width}
+        touchScrollEnabled
+        >
+          <Column header={<Cell>Name</Cell>} cell={<JobNameCell data={jobs} />} {...flexProps} />
+          <Column header={<Cell>Type</Cell>} cell={<JobTypeCell data={jobs} />} {...fixedProps} />
+          <Column header={<Cell>Priority</Cell>} cell={<JobPriorityCell data={jobs} />} {...fixedProps} />
+          <Column header={<Cell>Status</Cell>} cell={<JobStatusCell data={jobs} />} {...fixedProps} />
+          <Column header={<Cell>In Sync</Cell>} cell={<JobInSyncCell data={jobs} />} {...fixedProps} />
+          <Column header={<Cell>Groups</Cell>} cell={<JobGroupsCell data={jobs} />} {...fixedProps} />
+          <Column header={<Cell>Allocation Status</Cell>} cell={<JobAllocationStatusCell data={jobs} />} {...flexProps} />
+          <Column header={<Cell># Lost</Cell>} cell={<JobGroupsCell data={jobs} />} {...fixedProps} />
       </Table>
     )
   }

--- a/frontend/src/components/JobList/JobList.js
+++ b/frontend/src/components/JobList/JobList.js
@@ -18,8 +18,6 @@ const flexibleWidth = {
   whiteSpace: "normal"
 }
 
-const summaryLabels = ["Starting", "Running", "Queued", "Complete", "Failed", "Lost"]
-
 const taskGroupCount = job => {
     if (job.JobSummary !== null) {
       return Object.keys(job.JobSummary.Summary).length


### PR DESCRIPTION
Currently `JobList` doesn't use virtualized rendering; loading a large number of jobs basically makes the page unusable. This PR ports over virtualized table rendering setup from `AllocationList` to `JobList`.

Added benefit is this syncs the styles of `JobList` to match `AllocationList` (previously the headers had different formatting, I think the headers on AllocationList look nicer anyway).