### PR TITLE
Fix services -> in sync column stuck on question mark (jobs page)

### DIFF
--- a/frontend/src/components/JobHealth/JobHealth.js
+++ b/frontend/src/components/JobHealth/JobHealth.js
@@ -18,19 +18,34 @@ export { JobHealthCell }
 
 class JobHealth extends PureComponent {
   componentDidMount() {
+    this.watch(this.props.jobID);
+  }
+
+  componentWillUnmount() {
+    this.unwatch(this.props.jobID);
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.jobID !== this.props.jobID) {
+      this.unwatch(prevProps.jobID);
+      this.watch(this.props.jobID);
+    }
+  }
+
+  unwatch = jobID => {
     this.props.dispatch({
-      type: NOMAD_WATCH_JOB_HEALTH,
+      type: NOMAD_UNWATCH_JOB_HEALTH,
       payload: {
-        id: this.props.jobID
+        id: jobID
       }
     })
   }
 
-  componentWillUnmount() {
+  watch = jobID => {
     this.props.dispatch({
-      type: NOMAD_UNWATCH_JOB_HEALTH,
+      type: NOMAD_WATCH_JOB_HEALTH,
       payload: {
-        id: this.props.jobID
+        id: jobID
       }
     })
   }


### PR DESCRIPTION
got pretty stumped by this for a while. eventually added `console.log(this.props.jobID)` to `JobHealth->componentDidMount` and realized on all cases of stuck question mark, `componentDidMount` was never actually being called, so `NOMAD_WATCH_JOB_HEALTH` was never dispatched.

without digging too deep into *why*, i copied over [some logic from AllocationConsulHealth](https://github.com/jippi/hashi-ui/blob/3544b0c7e9a738a6adbec24852a181f39f2f6ee2/frontend/src/components/AllocationConsulHealth/AllocationConsulHealth.js#L21-L27) which fixed the issue. (we dispatch watch and unwatch when the job id prop changes in addition to mount / unmount.)

my best guess as to why this is happening is that maybe [fixed-data-table-2](https://github.com/schrodinger/fixed-data-table-2) reuses row components in the table and just passes new props, instead of unmounting the old cell and mounting a new one?