### PR TITLE
add linux-arm64 as build target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
     - CGO_ENABLED=0
     - DOCKER_BUILDKIT=1
     - GO111MODULE=on
-    - GOBUILD="linux-amd64 windows-amd64 darwin-amd64"
+    - GOBUILD="linux-amd64 windows-amd64 darwin-amd64 linux-arm64"
     - GOPROXY=https://proxy.golang.org
 
 # We depend on Docker 19.03 or newer for per-Dockerfile Dockerignore
@@ -49,6 +49,7 @@ deploy:
       - backend/build/hashi-ui-linux-amd64
       - backend/build/hashi-ui-windows-amd64
       - backend/build/hashi-ui-darwin-amd64
+      - backend/build/hashi-ui-linux-arm64
     skip_cleanup: true
     overwrite: true
     on:


### PR DESCRIPTION
simulating the build in docker using ubuntu, seems to just work.
I can do a PR for a multi-arch docker image as well, if we want to.